### PR TITLE
Sergei/clang crash repro

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,32 @@
+cc_library(
+    name = "llvm_headers",
+    hdrs = glob([
+        "llvm/include/**/*.h",
+        "llvm/include/llvm/Config/abi-breaking.h",
+    ]),
+    includes = [
+        "llvm/include",
+    ],
+)
+
+cc_library(
+    name = "mlir_headers",
+    hdrs = glob([
+        "mlir/include/**/*.h",
+        "mlir/include/**/*.h.inc",
+    ]),
+    includes = [
+        "mlir/include",
+    ],
+    deps = [
+        ":llvm_headers",
+    ],
+)
+
+cc_library(
+    name = "crash",
+    srcs = ["crash.cpp"],
+    deps = [":mlir_headers"],
+    copts = ["-Wno-unused-function"],
+)
+

--- a/crash.cpp
+++ b/crash.cpp
@@ -1,0 +1,9 @@
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+
+namespace mlir::foo {
+
+static Type bar(MLIRContext* context) {
+    return LLVM::LLVMVoidType::get(context);
+}
+
+}  // namespace mlir::foo

--- a/llvm/include/llvm/Config/abi-breaking.h
+++ b/llvm/include/llvm/Config/abi-breaking.h
@@ -1,0 +1,62 @@
+/*===------- llvm/Config/abi-breaking.h - llvm configuration -------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+/* This file controls the C++ ABI break introduced in LLVM public header. */
+
+#ifndef LLVM_ABI_BREAKING_CHECKS_H
+#define LLVM_ABI_BREAKING_CHECKS_H
+
+/* Define to enable checks that alter the LLVM C++ ABI */
+#define LLVM_ENABLE_ABI_BREAKING_CHECKS 0
+
+/* Define to enable reverse iteration of unordered llvm containers */
+#define LLVM_ENABLE_REVERSE_ITERATION 0
+
+/* Allow selectively disabling link-time mismatch checking so that header-only
+   ADT content from LLVM can be used without linking libSupport. */
+#if !defined(LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING) || !LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+
+// ABI_BREAKING_CHECKS protection: provides link-time failure when clients build
+// mismatch with LLVM
+#if defined(_MSC_VER)
+// Use pragma with MSVC
+#define LLVM_XSTR(s) LLVM_STR(s)
+#define LLVM_STR(s) #s
+#pragma detect_mismatch("LLVM_ENABLE_ABI_BREAKING_CHECKS", LLVM_XSTR(LLVM_ENABLE_ABI_BREAKING_CHECKS))
+#undef LLVM_XSTR
+#undef LLVM_STR
+#elif defined(_WIN32) || defined(__CYGWIN__) // Win32 w/o #pragma detect_mismatch
+// FIXME: Implement checks without weak.
+#elif defined(__cplusplus)
+#if !(defined(_AIX) && defined(__GNUC__) && !defined(__clang__))
+#define LLVM_HIDDEN_VISIBILITY __attribute__ ((visibility("hidden")))
+#else
+// GCC on AIX does not support visibility attributes. Symbols are not
+// exported by default on AIX.
+#define LLVM_HIDDEN_VISIBILITY
+#endif
+namespace llvm {
+#if LLVM_ENABLE_ABI_BREAKING_CHECKS
+extern int EnableABIBreakingChecks;
+LLVM_HIDDEN_VISIBILITY
+__attribute__((weak)) int *VerifyEnableABIBreakingChecks =
+    &EnableABIBreakingChecks;
+#else
+extern int DisableABIBreakingChecks;
+LLVM_HIDDEN_VISIBILITY
+__attribute__((weak)) int *VerifyDisableABIBreakingChecks =
+    &DisableABIBreakingChecks;
+#endif
+}
+#undef LLVM_HIDDEN_VISIBILITY
+#endif // _MSC_VER
+
+#endif // LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+
+#endif

--- a/llvm/include/llvm/Config/llvm-config.h
+++ b/llvm/include/llvm/Config/llvm-config.h
@@ -1,0 +1,127 @@
+/*===------- llvm/Config/llvm-config.h - llvm configuration -------*- C -*-===*/
+/*                                                                            */
+/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+/* Exceptions.                                                                */
+/* See https://llvm.org/LICENSE.txt for license information.                  */
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+/*                                                                            */
+/*===----------------------------------------------------------------------===*/
+
+/* This is a manual port of config.h.cmake for the symbols that do not change
+   based on platform. Those that do change should not be defined here and
+   instead use Bazel cc_library defines. Some attempt has been made to extract
+   such symbols that do vary based on platform (for the platforms we care about)
+   into Bazel defines, but it is by no means complete, so if you see something
+   that looks wrong, it probably is. */
+
+
+/* This file enumerates variables from the LLVM configuration so that they
+   can be in exported headers and won't override package specific directives.
+   This is a C header that can be included in the llvm-c headers. */
+
+#ifndef LLVM_CONFIG_H
+#define LLVM_CONFIG_H
+
+/* Define if LLVM_ENABLE_DUMP is enabled */
+/* #undef LLVM_ENABLE_DUMP */
+
+/* Target triple LLVM will generate code for by default */
+/* LLVM_DEFAULT_TARGET_TRIPLE defined in Bazel */
+
+/* Define if threads enabled */
+#define LLVM_ENABLE_THREADS 1
+
+/* Has gcc/MSVC atomic intrinsics */
+#define LLVM_HAS_ATOMICS 1
+
+/* Host triple LLVM will be executed on */
+/* LLVM_HOST_TRIPLE defined in Bazel */
+
+/* LLVM architecture name for the native architecture, if available */
+/* LLVM_NATIVE_ARCH defined in Bazel */
+
+/* LLVM name for the native AsmParser init function, if available */
+/* LLVM_NATIVE_ASMPARSER defined in Bazel */
+
+/* LLVM name for the native AsmPrinter init function, if available */
+/* LLVM_NATIVE_ASMPRINTER defined in Bazel */
+
+/* LLVM name for the native Disassembler init function, if available */
+/* LLVM_NATIVE_DISASSEMBLER defined in Bazel */
+
+/* LLVM name for the native Target init function, if available */
+/* LLVM_NATIVE_TARGET defined in Bazel */
+
+/* LLVM name for the native TargetInfo init function, if available */
+/* LLVM_NATIVE_TARGETINFO defined in Bazel */
+
+/* LLVM name for the native target MC init function, if available */
+/* LLVM_NATIVE_TARGETMC defined in Bazel */
+
+/* LLVM name for the native target MCA init function, if available */
+/* LLVM_NATIVE_TARGETMCA defined in Bazel */
+
+/* Define if this is Unixish platform */
+/* LLVM_ON_UNIX defined in Bazel */
+
+/* Define if we have the Intel JIT API runtime support library */
+#define LLVM_USE_INTEL_JITEVENTS 0
+
+/* Define if we have the oprofile JIT-support library */
+#define LLVM_USE_OPROFILE 0
+
+/* Define if we have the perf JIT-support library */
+#define LLVM_USE_PERF 0
+
+/* Major version of the LLVM API */
+#define LLVM_VERSION_MAJOR 16
+
+/* Minor version of the LLVM API */
+#define LLVM_VERSION_MINOR 0
+
+/* Patch version of the LLVM API */
+#define LLVM_VERSION_PATCH 0
+
+/* LLVM version string */
+#define LLVM_VERSION_STRING "16.0.0git"
+
+/* Whether LLVM records statistics for use with GetStatistics(),
+ * PrintStatistics() or PrintStatisticsJSON()
+ */
+#define LLVM_FORCE_ENABLE_STATS 0
+
+/* Define if we have z3 and want to build it */
+/* #undef LLVM_WITH_Z3 */
+
+/* Define if we have curl and want to use it */
+/* #undef LLVM_ENABLE_CURL */
+
+/* Define if we have cpp-httplib and want to use it */
+/* #undef LLVM_ENABLE_HTTPLIB */
+
+/* Define if LLVM was built with a dependency to the tensorflow compiler */
+/* #undef LLVM_HAVE_TF_AOT */
+
+/* Define to 1 if you have the <sysexits.h> header file. */
+/* HAVE_SYSEXITS_H defined in Bazel */
+
+/* Define if the xar_open() function is supported this platform. */
+/* #undef HAVE_LIBXAR */
+
+/* Define if building libLLVM shared library */
+/* #undef LLVM_BUILD_LLVM_DYLIB */
+
+/* Define if building LLVM with BUILD_SHARED_LIBS */
+/* #undef LLVM_BUILD_SHARED_LIBS */
+
+/* Define if building LLVM with LLVM_FORCE_USE_OLD_TOOLCHAIN_LIBS */
+/* #undef LLVM_FORCE_USE_OLD_TOOLCHAIN ${LLVM_FORCE_USE_OLD_TOOLCHAIN} */
+
+/* Define if llvm_unreachable should be optimized with undefined behavior
+ * in non assert builds */
+#define LLVM_UNREACHABLE_OPTIMIZE 1
+
+/* Define to 1 if you have the DIA SDK installed, and to 0 if you don't. */
+#define LLVM_ENABLE_DIA_SDK 0
+
+#endif

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.h.inc
@@ -1,0 +1,10931 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Op Declarations                                                            *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#if defined(GET_OP_CLASSES) || defined(GET_OP_FWD_DEFINES)
+#undef GET_OP_FWD_DEFINES
+namespace mlir {
+namespace LLVM {
+class AbsOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AssumeOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class BitReverseOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CallIntrinsicOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CopySignOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroAlignOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroBeginOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroEndOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroFreeOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroIdOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroResumeOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroSaveOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroSizeOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CoroSuspendOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CosOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CountLeadingZerosOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CountTrailingZerosOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CtPopOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class DbgAddrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class DbgDeclareOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class DbgValueOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class EhTypeidForOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class Exp2Op;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ExpOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FAbsOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FCeilOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FFloorOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FMAOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FMulAddOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FTruncOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class GetActiveLaneMaskOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class IsFPClass;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class LifetimeEndOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class LifetimeStartOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class Log10Op;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class Log2Op;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class LogOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MaskedLoadOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MaskedStoreOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MatrixColumnMajorLoadOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MatrixColumnMajorStoreOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MatrixMultiplyOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MatrixTransposeOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MaxNumOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MaximumOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MemcpyInlineOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MemcpyOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MemmoveOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MemsetOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MinNumOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MinimumOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class PowIOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class PowOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class Prefetch;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class RoundEvenOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class RoundOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SAddWithOverflowOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SMaxOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SMinOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SMulWithOverflowOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SSubWithOverflowOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SinOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SqrtOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class StackRestoreOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class StackSaveOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class StepVectorOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class UAddWithOverflowOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class UMaxOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class UMinOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class UMulWithOverflowOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class USubWithOverflowOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPAShrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPAddOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPAndOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFAddOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFDivOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFMulOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFNegOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFPExtOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFPToSIOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFPToUIOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFPTruncOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFRemOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFSubOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPFmaOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPIntToPtrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPLShrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPLoadOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPMergeMinOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPMulOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPOrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPPtrToIntOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceAddOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceAndOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceFAddOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceFMaxOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceFMinOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceFMulOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceMulOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceOrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceSMaxOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceSMinOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceUMaxOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceUMinOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPReduceXorOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPSDivOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPSExtOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPSIToFPOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPSRemOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPSelectMinOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPShlOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPStoreOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPStridedLoadOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPStridedStoreOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPSubOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPTruncOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPUDivOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPUIToFPOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPURemOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPXorOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VPZExtOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VaCopyOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VaEndOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class VaStartOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class masked_compressstore;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class masked_expandload;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class masked_gather;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class masked_scatter;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_extract;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_insert;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_add;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_and;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_fadd;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_fmax;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_fmin;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_fmul;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_mul;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_or;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_smax;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_smin;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_umax;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_umin;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vector_reduce_xor;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class vscale;
+} // namespace LLVM
+} // namespace mlir
+#endif
+
+#ifdef GET_OP_CLASSES
+#undef GET_OP_CLASSES
+
+
+//===----------------------------------------------------------------------===//
+// Local Utility Method Definitions
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AbsOp declarations
+//===----------------------------------------------------------------------===//
+
+class AbsOpAdaptor {
+public:
+  AbsOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AbsOpAdaptor(AbsOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::Value getIsIntMinPoison();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AbsOp : public ::mlir::Op<AbsOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AbsOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.abs");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::TypedValue<::mlir::IntegerType> getIsIntMinPoison();
+  ::mlir::MutableOperandRange getInMutable();
+  ::mlir::MutableOperandRange getIsIntMinPoisonMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::Value is_int_min_poison);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::Value is_int_min_poison);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AbsOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AssumeOp declarations
+//===----------------------------------------------------------------------===//
+
+class AssumeOpAdaptor {
+public:
+  AssumeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AssumeOpAdaptor(AssumeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getCond();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AssumeOp : public ::mlir::Op<AssumeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AssumeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.assume");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getCond();
+  ::mlir::MutableOperandRange getCondMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value cond);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value cond);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AssumeOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::BitReverseOp declarations
+//===----------------------------------------------------------------------===//
+
+class BitReverseOpAdaptor {
+public:
+  BitReverseOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BitReverseOpAdaptor(BitReverseOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class BitReverseOp : public ::mlir::Op<BitReverseOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BitReverseOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.bitreverse");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::BitReverseOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CallIntrinsicOp declarations
+//===----------------------------------------------------------------------===//
+
+class CallIntrinsicOpAdaptor {
+public:
+  CallIntrinsicOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CallIntrinsicOpAdaptor(CallIntrinsicOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::StringAttr getIntrinAttr();
+  ::llvm::StringRef getIntrin();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CallIntrinsicOp : public ::mlir::Op<CallIntrinsicOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::VariadicResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CallIntrinsicOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("intrin")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getIntrinAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getIntrinAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.call_intrinsic");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Operation::result_range getResults();
+  ::mlir::StringAttr getIntrinAttr();
+  ::llvm::StringRef getIntrin();
+  void setIntrinAttr(::mlir::StringAttr attr);
+  void setIntrin(::llvm::StringRef attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange results, ::mlir::StringAttr intrin, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange results, ::llvm::StringRef intrin, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CallIntrinsicOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CopySignOp declarations
+//===----------------------------------------------------------------------===//
+
+class CopySignOpAdaptor {
+public:
+  CopySignOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CopySignOpAdaptor(CopySignOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CopySignOp : public ::mlir::Op<CopySignOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CopySignOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.copysign");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CopySignOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroAlignOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroAlignOpAdaptor {
+public:
+  CoroAlignOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroAlignOpAdaptor(CoroAlignOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroAlignOp : public ::mlir::Op<CoroAlignOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroAlignOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.align");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroAlignOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroBeginOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroBeginOpAdaptor {
+public:
+  CoroBeginOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroBeginOpAdaptor(CoroBeginOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getToken();
+  ::mlir::Value getMem();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroBeginOp : public ::mlir::Op<CoroBeginOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroBeginOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.begin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getToken();
+  ::mlir::Value getMem();
+  ::mlir::MutableOperandRange getTokenMutable();
+  ::mlir::MutableOperandRange getMemMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value token, ::mlir::Value mem);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value token, ::mlir::Value mem);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroBeginOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroEndOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroEndOpAdaptor {
+public:
+  CoroEndOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroEndOpAdaptor(CoroEndOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getHandle();
+  ::mlir::Value getUnwind();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroEndOp : public ::mlir::Op<CoroEndOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroEndOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.end");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getHandle();
+  ::mlir::TypedValue<::mlir::IntegerType> getUnwind();
+  ::mlir::MutableOperandRange getHandleMutable();
+  ::mlir::MutableOperandRange getUnwindMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value handle, ::mlir::Value unwind);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value handle, ::mlir::Value unwind);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroEndOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroFreeOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroFreeOpAdaptor {
+public:
+  CoroFreeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroFreeOpAdaptor(CoroFreeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getId();
+  ::mlir::Value getHandle();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroFreeOp : public ::mlir::Op<CoroFreeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroFreeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.free");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getId();
+  ::mlir::Value getHandle();
+  ::mlir::MutableOperandRange getIdMutable();
+  ::mlir::MutableOperandRange getHandleMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value id, ::mlir::Value handle);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value id, ::mlir::Value handle);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroFreeOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroIdOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroIdOpAdaptor {
+public:
+  CoroIdOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroIdOpAdaptor(CoroIdOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getAlign();
+  ::mlir::Value getPromise();
+  ::mlir::Value getCoroaddr();
+  ::mlir::Value getFnaddrs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroIdOp : public ::mlir::Op<CoroIdOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroIdOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.id");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getAlign();
+  ::mlir::Value getPromise();
+  ::mlir::Value getCoroaddr();
+  ::mlir::Value getFnaddrs();
+  ::mlir::MutableOperandRange getAlignMutable();
+  ::mlir::MutableOperandRange getPromiseMutable();
+  ::mlir::MutableOperandRange getCoroaddrMutable();
+  ::mlir::MutableOperandRange getFnaddrsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value align, ::mlir::Value promise, ::mlir::Value coroaddr, ::mlir::Value fnaddrs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value align, ::mlir::Value promise, ::mlir::Value coroaddr, ::mlir::Value fnaddrs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroIdOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroResumeOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroResumeOpAdaptor {
+public:
+  CoroResumeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroResumeOpAdaptor(CoroResumeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getHandle();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroResumeOp : public ::mlir::Op<CoroResumeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroResumeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.resume");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getHandle();
+  ::mlir::MutableOperandRange getHandleMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value handle);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value handle);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroResumeOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroSaveOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroSaveOpAdaptor {
+public:
+  CoroSaveOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroSaveOpAdaptor(CoroSaveOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getHandle();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroSaveOp : public ::mlir::Op<CoroSaveOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroSaveOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.save");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getHandle();
+  ::mlir::MutableOperandRange getHandleMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value handle);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value handle);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroSaveOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroSizeOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroSizeOpAdaptor {
+public:
+  CoroSizeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroSizeOpAdaptor(CoroSizeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroSizeOp : public ::mlir::Op<CoroSizeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroSizeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.size");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroSizeOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CoroSuspendOp declarations
+//===----------------------------------------------------------------------===//
+
+class CoroSuspendOpAdaptor {
+public:
+  CoroSuspendOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CoroSuspendOpAdaptor(CoroSuspendOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSave();
+  ::mlir::Value getFinal();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CoroSuspendOp : public ::mlir::Op<CoroSuspendOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CoroSuspendOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.coro.suspend");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSave();
+  ::mlir::TypedValue<::mlir::IntegerType> getFinal();
+  ::mlir::MutableOperandRange getSaveMutable();
+  ::mlir::MutableOperandRange getFinalMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value save, ::mlir::Value final);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value save, ::mlir::Value final);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CoroSuspendOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CosOp declarations
+//===----------------------------------------------------------------------===//
+
+class CosOpAdaptor {
+public:
+  CosOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CosOpAdaptor(CosOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CosOp : public ::mlir::Op<CosOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CosOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.cos");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CosOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CountLeadingZerosOp declarations
+//===----------------------------------------------------------------------===//
+
+class CountLeadingZerosOpAdaptor {
+public:
+  CountLeadingZerosOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CountLeadingZerosOpAdaptor(CountLeadingZerosOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::Value getZeroUndefined();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CountLeadingZerosOp : public ::mlir::Op<CountLeadingZerosOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CountLeadingZerosOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.ctlz");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::TypedValue<::mlir::IntegerType> getZeroUndefined();
+  ::mlir::MutableOperandRange getInMutable();
+  ::mlir::MutableOperandRange getZeroUndefinedMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::Value zero_undefined);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::Value zero_undefined);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CountLeadingZerosOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CountTrailingZerosOp declarations
+//===----------------------------------------------------------------------===//
+
+class CountTrailingZerosOpAdaptor {
+public:
+  CountTrailingZerosOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CountTrailingZerosOpAdaptor(CountTrailingZerosOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::Value getZeroUndefined();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CountTrailingZerosOp : public ::mlir::Op<CountTrailingZerosOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CountTrailingZerosOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.cttz");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::TypedValue<::mlir::IntegerType> getZeroUndefined();
+  ::mlir::MutableOperandRange getInMutable();
+  ::mlir::MutableOperandRange getZeroUndefinedMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::Value zero_undefined);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::Value zero_undefined);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CountTrailingZerosOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CtPopOp declarations
+//===----------------------------------------------------------------------===//
+
+class CtPopOpAdaptor {
+public:
+  CtPopOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CtPopOpAdaptor(CtPopOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CtPopOp : public ::mlir::Op<CtPopOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CtPopOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.ctpop");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CtPopOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::DbgAddrOp declarations
+//===----------------------------------------------------------------------===//
+
+class DbgAddrOpAdaptor {
+public:
+  DbgAddrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  DbgAddrOpAdaptor(DbgAddrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getAddr();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfoAttr();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfo();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class DbgAddrOp : public ::mlir::Op<DbgAddrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = DbgAddrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("varInfo")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getVarInfoAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getVarInfoAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.dbg.addr");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getAddr();
+  ::mlir::MutableOperandRange getAddrMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::LLVM::DILocalVariableAttr getVarInfoAttr();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfo();
+  void setVarInfoAttr(::mlir::LLVM::DILocalVariableAttr attr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value addr, ::mlir::LLVM::DILocalVariableAttr varInfo);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value addr, ::mlir::LLVM::DILocalVariableAttr varInfo);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DbgAddrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::DbgDeclareOp declarations
+//===----------------------------------------------------------------------===//
+
+class DbgDeclareOpAdaptor {
+public:
+  DbgDeclareOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  DbgDeclareOpAdaptor(DbgDeclareOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getAddr();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfoAttr();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfo();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class DbgDeclareOp : public ::mlir::Op<DbgDeclareOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = DbgDeclareOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("varInfo")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getVarInfoAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getVarInfoAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.dbg.declare");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getAddr();
+  ::mlir::MutableOperandRange getAddrMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::LLVM::DILocalVariableAttr getVarInfoAttr();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfo();
+  void setVarInfoAttr(::mlir::LLVM::DILocalVariableAttr attr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value addr, ::mlir::LLVM::DILocalVariableAttr varInfo);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value addr, ::mlir::LLVM::DILocalVariableAttr varInfo);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DbgDeclareOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::DbgValueOp declarations
+//===----------------------------------------------------------------------===//
+
+class DbgValueOpAdaptor {
+public:
+  DbgValueOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  DbgValueOpAdaptor(DbgValueOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfoAttr();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfo();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class DbgValueOp : public ::mlir::Op<DbgValueOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = DbgValueOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("varInfo")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getVarInfoAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getVarInfoAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.dbg.value");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::MutableOperandRange getValueMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::LLVM::DILocalVariableAttr getVarInfoAttr();
+  ::mlir::LLVM::DILocalVariableAttr getVarInfo();
+  void setVarInfoAttr(::mlir::LLVM::DILocalVariableAttr attr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value, ::mlir::LLVM::DILocalVariableAttr varInfo);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value, ::mlir::LLVM::DILocalVariableAttr varInfo);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DbgValueOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::EhTypeidForOp declarations
+//===----------------------------------------------------------------------===//
+
+class EhTypeidForOpAdaptor {
+public:
+  EhTypeidForOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  EhTypeidForOpAdaptor(EhTypeidForOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getTypeInfo();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class EhTypeidForOp : public ::mlir::Op<EhTypeidForOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = EhTypeidForOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.eh.typeid.for");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getTypeInfo();
+  ::mlir::MutableOperandRange getTypeInfoMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value type_info);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value type_info);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::EhTypeidForOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::Exp2Op declarations
+//===----------------------------------------------------------------------===//
+
+class Exp2OpAdaptor {
+public:
+  Exp2OpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  Exp2OpAdaptor(Exp2Op op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class Exp2Op : public ::mlir::Op<Exp2Op, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = Exp2OpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.exp2");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::Exp2Op)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ExpOp declarations
+//===----------------------------------------------------------------------===//
+
+class ExpOpAdaptor {
+public:
+  ExpOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ExpOpAdaptor(ExpOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ExpOp : public ::mlir::Op<ExpOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ExpOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.exp");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ExpOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FAbsOp declarations
+//===----------------------------------------------------------------------===//
+
+class FAbsOpAdaptor {
+public:
+  FAbsOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FAbsOpAdaptor(FAbsOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FAbsOp : public ::mlir::Op<FAbsOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FAbsOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.fabs");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FAbsOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FCeilOp declarations
+//===----------------------------------------------------------------------===//
+
+class FCeilOpAdaptor {
+public:
+  FCeilOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FCeilOpAdaptor(FCeilOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FCeilOp : public ::mlir::Op<FCeilOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FCeilOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.ceil");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FCeilOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FFloorOp declarations
+//===----------------------------------------------------------------------===//
+
+class FFloorOpAdaptor {
+public:
+  FFloorOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FFloorOpAdaptor(FFloorOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FFloorOp : public ::mlir::Op<FFloorOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FFloorOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.floor");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FFloorOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FMAOp declarations
+//===----------------------------------------------------------------------===//
+
+class FMAOpAdaptor {
+public:
+  FMAOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FMAOpAdaptor(FMAOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::Value getC();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FMAOp : public ::mlir::Op<FMAOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FMAOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.fma");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::Value getC();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  ::mlir::MutableOperandRange getCMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FMAOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FMulAddOp declarations
+//===----------------------------------------------------------------------===//
+
+class FMulAddOpAdaptor {
+public:
+  FMulAddOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FMulAddOpAdaptor(FMulAddOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::Value getC();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FMulAddOp : public ::mlir::Op<FMulAddOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FMulAddOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.fmuladd");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::Value getC();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  ::mlir::MutableOperandRange getCMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::Value c, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FMulAddOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FTruncOp declarations
+//===----------------------------------------------------------------------===//
+
+class FTruncOpAdaptor {
+public:
+  FTruncOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FTruncOpAdaptor(FTruncOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FTruncOp : public ::mlir::Op<FTruncOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FTruncOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.trunc");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FTruncOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::GetActiveLaneMaskOp declarations
+//===----------------------------------------------------------------------===//
+
+class GetActiveLaneMaskOpAdaptor {
+public:
+  GetActiveLaneMaskOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GetActiveLaneMaskOpAdaptor(GetActiveLaneMaskOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getBase();
+  ::mlir::Value getN();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class GetActiveLaneMaskOp : public ::mlir::Op<GetActiveLaneMaskOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GetActiveLaneMaskOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.get.active.lane.mask");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getBase();
+  ::mlir::TypedValue<::mlir::IntegerType> getN();
+  ::mlir::MutableOperandRange getBaseMutable();
+  ::mlir::MutableOperandRange getNMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value base, ::mlir::Value n);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value base, ::mlir::Value n);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::GetActiveLaneMaskOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::IsFPClass declarations
+//===----------------------------------------------------------------------===//
+
+class IsFPClassAdaptor {
+public:
+  IsFPClassAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  IsFPClassAdaptor(IsFPClass op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::Value getBit();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class IsFPClass : public ::mlir::Op<IsFPClass, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = IsFPClassAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.is.fpclass");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::TypedValue<::mlir::IntegerType> getBit();
+  ::mlir::MutableOperandRange getInMutable();
+  ::mlir::MutableOperandRange getBitMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::Value bit);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::Value bit);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::IsFPClass)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::LifetimeEndOp declarations
+//===----------------------------------------------------------------------===//
+
+class LifetimeEndOpAdaptor {
+public:
+  LifetimeEndOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LifetimeEndOpAdaptor(LifetimeEndOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getSizeAttr();
+  uint64_t getSize();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class LifetimeEndOp : public ::mlir::Op<LifetimeEndOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LifetimeEndOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("size")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getSizeAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getSizeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.lifetime.end");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::MutableOperandRange getPtrMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::IntegerAttr getSizeAttr();
+  uint64_t getSize();
+  void setSizeAttr(::mlir::IntegerAttr attr);
+  void setSize(uint64_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::IntegerAttr size, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::IntegerAttr size, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, uint64_t size, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, uint64_t size, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LifetimeEndOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::LifetimeStartOp declarations
+//===----------------------------------------------------------------------===//
+
+class LifetimeStartOpAdaptor {
+public:
+  LifetimeStartOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LifetimeStartOpAdaptor(LifetimeStartOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getSizeAttr();
+  uint64_t getSize();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class LifetimeStartOp : public ::mlir::Op<LifetimeStartOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LifetimeStartOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("size")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getSizeAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getSizeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.lifetime.start");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::MutableOperandRange getPtrMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::IntegerAttr getSizeAttr();
+  uint64_t getSize();
+  void setSizeAttr(::mlir::IntegerAttr attr);
+  void setSize(uint64_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::IntegerAttr size, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::IntegerAttr size, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, uint64_t size, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, uint64_t size, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LifetimeStartOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::Log10Op declarations
+//===----------------------------------------------------------------------===//
+
+class Log10OpAdaptor {
+public:
+  Log10OpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  Log10OpAdaptor(Log10Op op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class Log10Op : public ::mlir::Op<Log10Op, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = Log10OpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.log10");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::Log10Op)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::Log2Op declarations
+//===----------------------------------------------------------------------===//
+
+class Log2OpAdaptor {
+public:
+  Log2OpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  Log2OpAdaptor(Log2Op op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class Log2Op : public ::mlir::Op<Log2Op, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = Log2OpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.log2");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::Log2Op)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::LogOp declarations
+//===----------------------------------------------------------------------===//
+
+class LogOpAdaptor {
+public:
+  LogOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LogOpAdaptor(LogOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class LogOp : public ::mlir::Op<LogOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LogOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.log");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LogOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MaskedLoadOp declarations
+//===----------------------------------------------------------------------===//
+
+class MaskedLoadOpAdaptor {
+public:
+  MaskedLoadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MaskedLoadOpAdaptor(MaskedLoadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getData();
+  ::mlir::Value getMask();
+  ::mlir::ValueRange getPassThru();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  uint32_t getAlignment();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MaskedLoadOp : public ::mlir::Op<MaskedLoadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::AtLeastNOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MaskedLoadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("alignment")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAlignmentAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAlignmentAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.masked.load");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getData();
+  ::mlir::Value getMask();
+  ::mlir::Operation::operand_range getPassThru();
+  ::mlir::MutableOperandRange getDataMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getPassThruMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  uint32_t getAlignment();
+  void setAlignmentAttr(::mlir::IntegerAttr attr);
+  void setAlignment(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value data, ::mlir::Value mask, ::mlir::ValueRange pass_thru, ::mlir::IntegerAttr alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value data, ::mlir::Value mask, ::mlir::ValueRange pass_thru, ::mlir::IntegerAttr alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value data, ::mlir::Value mask, ::mlir::ValueRange pass_thru, uint32_t alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value data, ::mlir::Value mask, ::mlir::ValueRange pass_thru, uint32_t alignment);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MaskedLoadOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MaskedStoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class MaskedStoreOpAdaptor {
+public:
+  MaskedStoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MaskedStoreOpAdaptor(MaskedStoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::Value getData();
+  ::mlir::Value getMask();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  uint32_t getAlignment();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MaskedStoreOp : public ::mlir::Op<MaskedStoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MaskedStoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("alignment")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAlignmentAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAlignmentAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.masked.store");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getData();
+  ::mlir::Value getMask();
+  ::mlir::MutableOperandRange getValueMutable();
+  ::mlir::MutableOperandRange getDataMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::IntegerAttr getAlignmentAttr();
+  uint32_t getAlignment();
+  void setAlignmentAttr(::mlir::IntegerAttr attr);
+  void setAlignment(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value, ::mlir::Value data, ::mlir::Value mask, ::mlir::IntegerAttr alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value, ::mlir::Value data, ::mlir::Value mask, ::mlir::IntegerAttr alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value, ::mlir::Value data, ::mlir::Value mask, uint32_t alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value, ::mlir::Value data, ::mlir::Value mask, uint32_t alignment);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MaskedStoreOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MatrixColumnMajorLoadOp declarations
+//===----------------------------------------------------------------------===//
+
+class MatrixColumnMajorLoadOpAdaptor {
+public:
+  MatrixColumnMajorLoadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MatrixColumnMajorLoadOpAdaptor(MatrixColumnMajorLoadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getData();
+  ::mlir::Value getStride();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getIsVolatileAttr();
+  bool getIsVolatile();
+  ::mlir::IntegerAttr getRowsAttr();
+  uint32_t getRows();
+  ::mlir::IntegerAttr getColumnsAttr();
+  uint32_t getColumns();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MatrixColumnMajorLoadOp : public ::mlir::Op<MatrixColumnMajorLoadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MatrixColumnMajorLoadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("columns"), ::llvm::StringRef("isVolatile"), ::llvm::StringRef("rows")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getColumnsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getColumnsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getIsVolatileAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getIsVolatileAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getRowsAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getRowsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.matrix.column.major.load");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getData();
+  ::mlir::TypedValue<::mlir::IntegerType> getStride();
+  ::mlir::MutableOperandRange getDataMutable();
+  ::mlir::MutableOperandRange getStrideMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getIsVolatileAttr();
+  bool getIsVolatile();
+  ::mlir::IntegerAttr getRowsAttr();
+  uint32_t getRows();
+  ::mlir::IntegerAttr getColumnsAttr();
+  uint32_t getColumns();
+  void setIsVolatileAttr(::mlir::IntegerAttr attr);
+  void setIsVolatile(bool attrValue);
+  void setRowsAttr(::mlir::IntegerAttr attr);
+  void setRows(uint32_t attrValue);
+  void setColumnsAttr(::mlir::IntegerAttr attr);
+  void setColumns(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value data, ::mlir::Value stride, ::mlir::IntegerAttr isVolatile, ::mlir::IntegerAttr rows, ::mlir::IntegerAttr columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value data, ::mlir::Value stride, ::mlir::IntegerAttr isVolatile, ::mlir::IntegerAttr rows, ::mlir::IntegerAttr columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value data, ::mlir::Value stride, bool isVolatile, uint32_t rows, uint32_t columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value data, ::mlir::Value stride, bool isVolatile, uint32_t rows, uint32_t columns);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 3 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MatrixColumnMajorLoadOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MatrixColumnMajorStoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class MatrixColumnMajorStoreOpAdaptor {
+public:
+  MatrixColumnMajorStoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MatrixColumnMajorStoreOpAdaptor(MatrixColumnMajorStoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getMatrix();
+  ::mlir::Value getData();
+  ::mlir::Value getStride();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getIsVolatileAttr();
+  bool getIsVolatile();
+  ::mlir::IntegerAttr getRowsAttr();
+  uint32_t getRows();
+  ::mlir::IntegerAttr getColumnsAttr();
+  uint32_t getColumns();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MatrixColumnMajorStoreOp : public ::mlir::Op<MatrixColumnMajorStoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MatrixColumnMajorStoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("columns"), ::llvm::StringRef("isVolatile"), ::llvm::StringRef("rows")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getColumnsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getColumnsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getIsVolatileAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getIsVolatileAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getRowsAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getRowsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.matrix.column.major.store");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getMatrix();
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getData();
+  ::mlir::TypedValue<::mlir::IntegerType> getStride();
+  ::mlir::MutableOperandRange getMatrixMutable();
+  ::mlir::MutableOperandRange getDataMutable();
+  ::mlir::MutableOperandRange getStrideMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::IntegerAttr getIsVolatileAttr();
+  bool getIsVolatile();
+  ::mlir::IntegerAttr getRowsAttr();
+  uint32_t getRows();
+  ::mlir::IntegerAttr getColumnsAttr();
+  uint32_t getColumns();
+  void setIsVolatileAttr(::mlir::IntegerAttr attr);
+  void setIsVolatile(bool attrValue);
+  void setRowsAttr(::mlir::IntegerAttr attr);
+  void setRows(uint32_t attrValue);
+  void setColumnsAttr(::mlir::IntegerAttr attr);
+  void setColumns(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value matrix, ::mlir::Value data, ::mlir::Value stride, ::mlir::IntegerAttr isVolatile, ::mlir::IntegerAttr rows, ::mlir::IntegerAttr columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value matrix, ::mlir::Value data, ::mlir::Value stride, ::mlir::IntegerAttr isVolatile, ::mlir::IntegerAttr rows, ::mlir::IntegerAttr columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value matrix, ::mlir::Value data, ::mlir::Value stride, bool isVolatile, uint32_t rows, uint32_t columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value matrix, ::mlir::Value data, ::mlir::Value stride, bool isVolatile, uint32_t rows, uint32_t columns);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 3 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MatrixColumnMajorStoreOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MatrixMultiplyOp declarations
+//===----------------------------------------------------------------------===//
+
+class MatrixMultiplyOpAdaptor {
+public:
+  MatrixMultiplyOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MatrixMultiplyOpAdaptor(MatrixMultiplyOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getLhsRowsAttr();
+  uint32_t getLhsRows();
+  ::mlir::IntegerAttr getLhsColumnsAttr();
+  uint32_t getLhsColumns();
+  ::mlir::IntegerAttr getRhsColumnsAttr();
+  uint32_t getRhsColumns();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MatrixMultiplyOp : public ::mlir::Op<MatrixMultiplyOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MatrixMultiplyOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("lhs_columns"), ::llvm::StringRef("lhs_rows"), ::llvm::StringRef("rhs_columns")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getLhsColumnsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getLhsColumnsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getLhsRowsAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getLhsRowsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getRhsColumnsAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getRhsColumnsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.matrix.multiply");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getLhsRowsAttr();
+  uint32_t getLhsRows();
+  ::mlir::IntegerAttr getLhsColumnsAttr();
+  uint32_t getLhsColumns();
+  ::mlir::IntegerAttr getRhsColumnsAttr();
+  uint32_t getRhsColumns();
+  void setLhsRowsAttr(::mlir::IntegerAttr attr);
+  void setLhsRows(uint32_t attrValue);
+  void setLhsColumnsAttr(::mlir::IntegerAttr attr);
+  void setLhsColumns(uint32_t attrValue);
+  void setRhsColumnsAttr(::mlir::IntegerAttr attr);
+  void setRhsColumns(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::IntegerAttr lhs_rows, ::mlir::IntegerAttr lhs_columns, ::mlir::IntegerAttr rhs_columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::IntegerAttr lhs_rows, ::mlir::IntegerAttr lhs_columns, ::mlir::IntegerAttr rhs_columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, uint32_t lhs_rows, uint32_t lhs_columns, uint32_t rhs_columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, uint32_t lhs_rows, uint32_t lhs_columns, uint32_t rhs_columns);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 3 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MatrixMultiplyOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MatrixTransposeOp declarations
+//===----------------------------------------------------------------------===//
+
+class MatrixTransposeOpAdaptor {
+public:
+  MatrixTransposeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MatrixTransposeOpAdaptor(MatrixTransposeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getMatrix();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getRowsAttr();
+  uint32_t getRows();
+  ::mlir::IntegerAttr getColumnsAttr();
+  uint32_t getColumns();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MatrixTransposeOp : public ::mlir::Op<MatrixTransposeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MatrixTransposeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("columns"), ::llvm::StringRef("rows")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getColumnsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getColumnsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getRowsAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getRowsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.matrix.transpose");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getMatrix();
+  ::mlir::MutableOperandRange getMatrixMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getRowsAttr();
+  uint32_t getRows();
+  ::mlir::IntegerAttr getColumnsAttr();
+  uint32_t getColumns();
+  void setRowsAttr(::mlir::IntegerAttr attr);
+  void setRows(uint32_t attrValue);
+  void setColumnsAttr(::mlir::IntegerAttr attr);
+  void setColumns(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value matrix, ::mlir::IntegerAttr rows, ::mlir::IntegerAttr columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value matrix, ::mlir::IntegerAttr rows, ::mlir::IntegerAttr columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value matrix, uint32_t rows, uint32_t columns);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value matrix, uint32_t rows, uint32_t columns);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MatrixTransposeOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MaxNumOp declarations
+//===----------------------------------------------------------------------===//
+
+class MaxNumOpAdaptor {
+public:
+  MaxNumOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MaxNumOpAdaptor(MaxNumOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MaxNumOp : public ::mlir::Op<MaxNumOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MaxNumOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.maxnum");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MaxNumOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MaximumOp declarations
+//===----------------------------------------------------------------------===//
+
+class MaximumOpAdaptor {
+public:
+  MaximumOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MaximumOpAdaptor(MaximumOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MaximumOp : public ::mlir::Op<MaximumOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MaximumOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.maximum");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MaximumOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MemcpyInlineOp declarations
+//===----------------------------------------------------------------------===//
+
+class MemcpyInlineOpAdaptor {
+public:
+  MemcpyInlineOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MemcpyInlineOpAdaptor(MemcpyInlineOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getDst();
+  ::mlir::Value getSrc();
+  ::mlir::Value getLen();
+  ::mlir::Value getIsVolatile();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MemcpyInlineOp : public ::mlir::Op<MemcpyInlineOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MemcpyInlineOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.memcpy.inline");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getDst();
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getSrc();
+  ::mlir::TypedValue<::mlir::IntegerType> getLen();
+  ::mlir::TypedValue<::mlir::IntegerType> getIsVolatile();
+  ::mlir::MutableOperandRange getDstMutable();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getLenMutable();
+  ::mlir::MutableOperandRange getIsVolatileMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value dst, ::mlir::Value src, ::mlir::Value len, ::mlir::Value isVolatile);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dst, ::mlir::Value src, ::mlir::Value len, ::mlir::Value isVolatile);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MemcpyInlineOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MemcpyOp declarations
+//===----------------------------------------------------------------------===//
+
+class MemcpyOpAdaptor {
+public:
+  MemcpyOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MemcpyOpAdaptor(MemcpyOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getDst();
+  ::mlir::Value getSrc();
+  ::mlir::Value getLen();
+  ::mlir::Value getIsVolatile();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MemcpyOp : public ::mlir::Op<MemcpyOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MemcpyOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.memcpy");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getDst();
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getSrc();
+  ::mlir::TypedValue<::mlir::IntegerType> getLen();
+  ::mlir::TypedValue<::mlir::IntegerType> getIsVolatile();
+  ::mlir::MutableOperandRange getDstMutable();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getLenMutable();
+  ::mlir::MutableOperandRange getIsVolatileMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value dst, ::mlir::Value src, ::mlir::Value len, ::mlir::Value isVolatile);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dst, ::mlir::Value src, ::mlir::Value len, ::mlir::Value isVolatile);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MemcpyOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MemmoveOp declarations
+//===----------------------------------------------------------------------===//
+
+class MemmoveOpAdaptor {
+public:
+  MemmoveOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MemmoveOpAdaptor(MemmoveOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getDst();
+  ::mlir::Value getSrc();
+  ::mlir::Value getLen();
+  ::mlir::Value getIsVolatile();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MemmoveOp : public ::mlir::Op<MemmoveOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MemmoveOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.memmove");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getDst();
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getSrc();
+  ::mlir::TypedValue<::mlir::IntegerType> getLen();
+  ::mlir::TypedValue<::mlir::IntegerType> getIsVolatile();
+  ::mlir::MutableOperandRange getDstMutable();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getLenMutable();
+  ::mlir::MutableOperandRange getIsVolatileMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value dst, ::mlir::Value src, ::mlir::Value len, ::mlir::Value isVolatile);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dst, ::mlir::Value src, ::mlir::Value len, ::mlir::Value isVolatile);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MemmoveOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MemsetOp declarations
+//===----------------------------------------------------------------------===//
+
+class MemsetOpAdaptor {
+public:
+  MemsetOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MemsetOpAdaptor(MemsetOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getDst();
+  ::mlir::Value getVal();
+  ::mlir::Value getLen();
+  ::mlir::Value getIsVolatile();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MemsetOp : public ::mlir::Op<MemsetOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MemsetOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.memset");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getDst();
+  ::mlir::TypedValue<::mlir::IntegerType> getVal();
+  ::mlir::TypedValue<::mlir::IntegerType> getLen();
+  ::mlir::TypedValue<::mlir::IntegerType> getIsVolatile();
+  ::mlir::MutableOperandRange getDstMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getLenMutable();
+  ::mlir::MutableOperandRange getIsVolatileMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value dst, ::mlir::Value val, ::mlir::Value len, ::mlir::Value isVolatile);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dst, ::mlir::Value val, ::mlir::Value len, ::mlir::Value isVolatile);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MemsetOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MinNumOp declarations
+//===----------------------------------------------------------------------===//
+
+class MinNumOpAdaptor {
+public:
+  MinNumOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MinNumOpAdaptor(MinNumOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MinNumOp : public ::mlir::Op<MinNumOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MinNumOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.minnum");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MinNumOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MinimumOp declarations
+//===----------------------------------------------------------------------===//
+
+class MinimumOpAdaptor {
+public:
+  MinimumOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MinimumOpAdaptor(MinimumOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MinimumOp : public ::mlir::Op<MinimumOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MinimumOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.minimum");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MinimumOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::PowIOp declarations
+//===----------------------------------------------------------------------===//
+
+class PowIOpAdaptor {
+public:
+  PowIOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  PowIOpAdaptor(PowIOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVal();
+  ::mlir::Value getPower();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class PowIOp : public ::mlir::Op<PowIOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = PowIOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.powi");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVal();
+  ::mlir::TypedValue<::mlir::IntegerType> getPower();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getPowerMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value val, ::mlir::Value power, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value val, ::mlir::Value power, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value val, ::mlir::Value power, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value val, ::mlir::Value power, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::PowIOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::PowOp declarations
+//===----------------------------------------------------------------------===//
+
+class PowOpAdaptor {
+public:
+  PowOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  PowOpAdaptor(PowOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class PowOp : public ::mlir::Op<PowOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = PowOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.pow");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::PowOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::Prefetch declarations
+//===----------------------------------------------------------------------===//
+
+class PrefetchAdaptor {
+public:
+  PrefetchAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  PrefetchAdaptor(Prefetch op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getAddr();
+  ::mlir::Value getRw();
+  ::mlir::Value getHint();
+  ::mlir::Value getCache();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class Prefetch : public ::mlir::Op<Prefetch, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = PrefetchAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.prefetch");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getAddr();
+  ::mlir::TypedValue<::mlir::IntegerType> getRw();
+  ::mlir::TypedValue<::mlir::IntegerType> getHint();
+  ::mlir::TypedValue<::mlir::IntegerType> getCache();
+  ::mlir::MutableOperandRange getAddrMutable();
+  ::mlir::MutableOperandRange getRwMutable();
+  ::mlir::MutableOperandRange getHintMutable();
+  ::mlir::MutableOperandRange getCacheMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value addr, ::mlir::Value rw, ::mlir::Value hint, ::mlir::Value cache);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value addr, ::mlir::Value rw, ::mlir::Value hint, ::mlir::Value cache);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::Prefetch)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::RoundEvenOp declarations
+//===----------------------------------------------------------------------===//
+
+class RoundEvenOpAdaptor {
+public:
+  RoundEvenOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  RoundEvenOpAdaptor(RoundEvenOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class RoundEvenOp : public ::mlir::Op<RoundEvenOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = RoundEvenOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.roundeven");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::RoundEvenOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::RoundOp declarations
+//===----------------------------------------------------------------------===//
+
+class RoundOpAdaptor {
+public:
+  RoundOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  RoundOpAdaptor(RoundOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class RoundOp : public ::mlir::Op<RoundOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = RoundOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.round");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::RoundOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SAddWithOverflowOp declarations
+//===----------------------------------------------------------------------===//
+
+class SAddWithOverflowOpAdaptor {
+public:
+  SAddWithOverflowOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SAddWithOverflowOpAdaptor(SAddWithOverflowOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SAddWithOverflowOp : public ::mlir::Op<SAddWithOverflowOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::SameOperandsElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SAddWithOverflowOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.sadd.with.overflow");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SAddWithOverflowOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SMaxOp declarations
+//===----------------------------------------------------------------------===//
+
+class SMaxOpAdaptor {
+public:
+  SMaxOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SMaxOpAdaptor(SMaxOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SMaxOp : public ::mlir::Op<SMaxOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SMaxOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.smax");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SMaxOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SMinOp declarations
+//===----------------------------------------------------------------------===//
+
+class SMinOpAdaptor {
+public:
+  SMinOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SMinOpAdaptor(SMinOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SMinOp : public ::mlir::Op<SMinOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SMinOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.smin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SMinOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SMulWithOverflowOp declarations
+//===----------------------------------------------------------------------===//
+
+class SMulWithOverflowOpAdaptor {
+public:
+  SMulWithOverflowOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SMulWithOverflowOpAdaptor(SMulWithOverflowOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SMulWithOverflowOp : public ::mlir::Op<SMulWithOverflowOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::SameOperandsElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SMulWithOverflowOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.smul.with.overflow");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SMulWithOverflowOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SSubWithOverflowOp declarations
+//===----------------------------------------------------------------------===//
+
+class SSubWithOverflowOpAdaptor {
+public:
+  SSubWithOverflowOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SSubWithOverflowOpAdaptor(SSubWithOverflowOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SSubWithOverflowOp : public ::mlir::Op<SSubWithOverflowOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::SameOperandsElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SSubWithOverflowOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.ssub.with.overflow");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SSubWithOverflowOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SinOp declarations
+//===----------------------------------------------------------------------===//
+
+class SinOpAdaptor {
+public:
+  SinOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SinOpAdaptor(SinOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SinOp : public ::mlir::Op<SinOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SinOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.sin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SinOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SqrtOp declarations
+//===----------------------------------------------------------------------===//
+
+class SqrtOpAdaptor {
+public:
+  SqrtOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SqrtOpAdaptor(SqrtOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SqrtOp : public ::mlir::Op<SqrtOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SqrtOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.sqrt");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getIn();
+  ::mlir::MutableOperandRange getInMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value in, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SqrtOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::StackRestoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class StackRestoreOpAdaptor {
+public:
+  StackRestoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  StackRestoreOpAdaptor(StackRestoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class StackRestoreOp : public ::mlir::Op<StackRestoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = StackRestoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.stackrestore");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::MutableOperandRange getPtrMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::StackRestoreOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::StackSaveOp declarations
+//===----------------------------------------------------------------------===//
+
+class StackSaveOpAdaptor {
+public:
+  StackSaveOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  StackSaveOpAdaptor(StackSaveOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class StackSaveOp : public ::mlir::Op<StackSaveOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = StackSaveOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.stacksave");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::StackSaveOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::StepVectorOp declarations
+//===----------------------------------------------------------------------===//
+
+class StepVectorOpAdaptor {
+public:
+  StepVectorOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  StepVectorOpAdaptor(StepVectorOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class StepVectorOp : public ::mlir::Op<StepVectorOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = StepVectorOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.experimental.stepvector");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::StepVectorOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::UAddWithOverflowOp declarations
+//===----------------------------------------------------------------------===//
+
+class UAddWithOverflowOpAdaptor {
+public:
+  UAddWithOverflowOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UAddWithOverflowOpAdaptor(UAddWithOverflowOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UAddWithOverflowOp : public ::mlir::Op<UAddWithOverflowOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::SameOperandsElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UAddWithOverflowOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.uadd.with.overflow");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::UAddWithOverflowOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::UMaxOp declarations
+//===----------------------------------------------------------------------===//
+
+class UMaxOpAdaptor {
+public:
+  UMaxOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UMaxOpAdaptor(UMaxOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UMaxOp : public ::mlir::Op<UMaxOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UMaxOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.umax");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::UMaxOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::UMinOp declarations
+//===----------------------------------------------------------------------===//
+
+class UMinOpAdaptor {
+public:
+  UMinOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UMinOpAdaptor(UMinOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UMinOp : public ::mlir::Op<UMinOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UMinOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.umin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getA();
+  ::mlir::Value getB();
+  ::mlir::MutableOperandRange getAMutable();
+  ::mlir::MutableOperandRange getBMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value a, ::mlir::Value b);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::UMinOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::UMulWithOverflowOp declarations
+//===----------------------------------------------------------------------===//
+
+class UMulWithOverflowOpAdaptor {
+public:
+  UMulWithOverflowOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UMulWithOverflowOpAdaptor(UMulWithOverflowOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UMulWithOverflowOp : public ::mlir::Op<UMulWithOverflowOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::SameOperandsElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UMulWithOverflowOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.umul.with.overflow");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::UMulWithOverflowOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::USubWithOverflowOp declarations
+//===----------------------------------------------------------------------===//
+
+class USubWithOverflowOpAdaptor {
+public:
+  USubWithOverflowOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  USubWithOverflowOpAdaptor(USubWithOverflowOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class USubWithOverflowOp : public ::mlir::Op<USubWithOverflowOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::SameOperandsElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = USubWithOverflowOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.usub.with.overflow");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::USubWithOverflowOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPAShrOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPAShrOpAdaptor {
+public:
+  VPAShrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPAShrOpAdaptor(VPAShrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPAShrOp : public ::mlir::Op<VPAShrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPAShrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.ashr");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPAShrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPAddOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPAddOpAdaptor {
+public:
+  VPAddOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPAddOpAdaptor(VPAddOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPAddOp : public ::mlir::Op<VPAddOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPAddOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.add");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPAddOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPAndOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPAndOpAdaptor {
+public:
+  VPAndOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPAndOpAdaptor(VPAndOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPAndOp : public ::mlir::Op<VPAndOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPAndOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.and");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPAndOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFAddOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFAddOpAdaptor {
+public:
+  VPFAddOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFAddOpAdaptor(VPFAddOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFAddOp : public ::mlir::Op<VPFAddOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFAddOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fadd");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFAddOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFDivOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFDivOpAdaptor {
+public:
+  VPFDivOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFDivOpAdaptor(VPFDivOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFDivOp : public ::mlir::Op<VPFDivOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFDivOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fdiv");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFDivOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFMulOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFMulOpAdaptor {
+public:
+  VPFMulOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFMulOpAdaptor(VPFMulOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFMulOp : public ::mlir::Op<VPFMulOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFMulOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fmul");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFMulOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFNegOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFNegOpAdaptor {
+public:
+  VPFNegOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFNegOpAdaptor(VPFNegOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getOp();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFNegOp : public ::mlir::Op<VPFNegOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFNegOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fneg");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getOp();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getOpMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value op, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value op, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFNegOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFPExtOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFPExtOpAdaptor {
+public:
+  VPFPExtOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFPExtOpAdaptor(VPFPExtOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFPExtOp : public ::mlir::Op<VPFPExtOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFPExtOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fpext");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFPExtOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFPToSIOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFPToSIOpAdaptor {
+public:
+  VPFPToSIOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFPToSIOpAdaptor(VPFPToSIOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFPToSIOp : public ::mlir::Op<VPFPToSIOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFPToSIOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fptosi");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFPToSIOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFPToUIOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFPToUIOpAdaptor {
+public:
+  VPFPToUIOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFPToUIOpAdaptor(VPFPToUIOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFPToUIOp : public ::mlir::Op<VPFPToUIOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFPToUIOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fptoui");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFPToUIOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFPTruncOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFPTruncOpAdaptor {
+public:
+  VPFPTruncOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFPTruncOpAdaptor(VPFPTruncOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFPTruncOp : public ::mlir::Op<VPFPTruncOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFPTruncOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fptrunc");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFPTruncOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFRemOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFRemOpAdaptor {
+public:
+  VPFRemOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFRemOpAdaptor(VPFRemOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFRemOp : public ::mlir::Op<VPFRemOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFRemOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.frem");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFRemOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFSubOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFSubOpAdaptor {
+public:
+  VPFSubOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFSubOpAdaptor(VPFSubOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFSubOp : public ::mlir::Op<VPFSubOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFSubOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fsub");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFSubOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPFmaOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPFmaOpAdaptor {
+public:
+  VPFmaOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPFmaOpAdaptor(VPFmaOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getOp1();
+  ::mlir::Value getOp2();
+  ::mlir::Value getOp3();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPFmaOp : public ::mlir::Op<VPFmaOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<5>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPFmaOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.fma");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getOp1();
+  ::mlir::Value getOp2();
+  ::mlir::Value getOp3();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getOp1Mutable();
+  ::mlir::MutableOperandRange getOp2Mutable();
+  ::mlir::MutableOperandRange getOp3Mutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value op1, ::mlir::Value op2, ::mlir::Value op3, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value op1, ::mlir::Value op2, ::mlir::Value op3, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPFmaOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPIntToPtrOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPIntToPtrOpAdaptor {
+public:
+  VPIntToPtrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPIntToPtrOpAdaptor(VPIntToPtrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPIntToPtrOp : public ::mlir::Op<VPIntToPtrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPIntToPtrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.inttoptr");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPIntToPtrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPLShrOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPLShrOpAdaptor {
+public:
+  VPLShrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPLShrOpAdaptor(VPLShrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPLShrOp : public ::mlir::Op<VPLShrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPLShrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.lshr");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPLShrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPLoadOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPLoadOpAdaptor {
+public:
+  VPLoadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPLoadOpAdaptor(VPLoadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPLoadOp : public ::mlir::Op<VPLoadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPLoadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.load");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getPtrMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptr, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPLoadOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPMergeMinOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPMergeMinOpAdaptor {
+public:
+  VPMergeMinOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPMergeMinOpAdaptor(VPMergeMinOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getCond();
+  ::mlir::Value getTrueVal();
+  ::mlir::Value getFalseVal();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPMergeMinOp : public ::mlir::Op<VPMergeMinOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPMergeMinOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.merge");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getCond();
+  ::mlir::Value getTrueVal();
+  ::mlir::Value getFalseVal();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getCondMutable();
+  ::mlir::MutableOperandRange getTrueValMutable();
+  ::mlir::MutableOperandRange getFalseValMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value cond, ::mlir::Value true_val, ::mlir::Value false_val, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value cond, ::mlir::Value true_val, ::mlir::Value false_val, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPMergeMinOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPMulOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPMulOpAdaptor {
+public:
+  VPMulOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPMulOpAdaptor(VPMulOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPMulOp : public ::mlir::Op<VPMulOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPMulOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.mul");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPMulOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPOrOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPOrOpAdaptor {
+public:
+  VPOrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPOrOpAdaptor(VPOrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPOrOp : public ::mlir::Op<VPOrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPOrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.or");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPOrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPPtrToIntOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPPtrToIntOpAdaptor {
+public:
+  VPPtrToIntOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPPtrToIntOpAdaptor(VPPtrToIntOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPPtrToIntOp : public ::mlir::Op<VPPtrToIntOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPPtrToIntOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.ptrtoint");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPPtrToIntOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceAddOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceAddOpAdaptor {
+public:
+  VPReduceAddOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceAddOpAdaptor(VPReduceAddOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceAddOp : public ::mlir::Op<VPReduceAddOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceAddOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.add");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceAddOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceAndOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceAndOpAdaptor {
+public:
+  VPReduceAndOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceAndOpAdaptor(VPReduceAndOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceAndOp : public ::mlir::Op<VPReduceAndOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceAndOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.and");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceAndOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceFAddOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceFAddOpAdaptor {
+public:
+  VPReduceFAddOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceFAddOpAdaptor(VPReduceFAddOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceFAddOp : public ::mlir::Op<VPReduceFAddOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceFAddOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.fadd");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::FloatType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceFAddOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceFMaxOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceFMaxOpAdaptor {
+public:
+  VPReduceFMaxOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceFMaxOpAdaptor(VPReduceFMaxOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceFMaxOp : public ::mlir::Op<VPReduceFMaxOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceFMaxOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.fmax");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::FloatType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceFMaxOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceFMinOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceFMinOpAdaptor {
+public:
+  VPReduceFMinOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceFMinOpAdaptor(VPReduceFMinOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceFMinOp : public ::mlir::Op<VPReduceFMinOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceFMinOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.fmin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::FloatType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceFMinOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceFMulOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceFMulOpAdaptor {
+public:
+  VPReduceFMulOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceFMulOpAdaptor(VPReduceFMulOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceFMulOp : public ::mlir::Op<VPReduceFMulOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceFMulOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.fmul");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::FloatType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceFMulOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceMulOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceMulOpAdaptor {
+public:
+  VPReduceMulOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceMulOpAdaptor(VPReduceMulOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceMulOp : public ::mlir::Op<VPReduceMulOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceMulOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.mul");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceMulOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceOrOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceOrOpAdaptor {
+public:
+  VPReduceOrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceOrOpAdaptor(VPReduceOrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceOrOp : public ::mlir::Op<VPReduceOrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceOrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.or");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceOrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceSMaxOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceSMaxOpAdaptor {
+public:
+  VPReduceSMaxOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceSMaxOpAdaptor(VPReduceSMaxOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceSMaxOp : public ::mlir::Op<VPReduceSMaxOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceSMaxOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.smax");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceSMaxOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceSMinOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceSMinOpAdaptor {
+public:
+  VPReduceSMinOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceSMinOpAdaptor(VPReduceSMinOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceSMinOp : public ::mlir::Op<VPReduceSMinOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceSMinOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.smin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceSMinOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceUMaxOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceUMaxOpAdaptor {
+public:
+  VPReduceUMaxOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceUMaxOpAdaptor(VPReduceUMaxOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceUMaxOp : public ::mlir::Op<VPReduceUMaxOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceUMaxOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.umax");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceUMaxOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceUMinOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceUMinOpAdaptor {
+public:
+  VPReduceUMinOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceUMinOpAdaptor(VPReduceUMinOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceUMinOp : public ::mlir::Op<VPReduceUMinOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceUMinOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.umin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceUMinOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPReduceXorOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPReduceXorOpAdaptor {
+public:
+  VPReduceXorOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPReduceXorOpAdaptor(VPReduceXorOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPReduceXorOp : public ::mlir::Op<VPReduceXorOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPReduceXorOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.reduce.xor");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getSatrtValue();
+  ::mlir::Value getVal();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSatrtValueMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value satrt_value, ::mlir::Value val, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPReduceXorOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPSDivOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPSDivOpAdaptor {
+public:
+  VPSDivOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPSDivOpAdaptor(VPSDivOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPSDivOp : public ::mlir::Op<VPSDivOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPSDivOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.sdiv");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPSDivOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPSExtOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPSExtOpAdaptor {
+public:
+  VPSExtOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPSExtOpAdaptor(VPSExtOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPSExtOp : public ::mlir::Op<VPSExtOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPSExtOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.sext");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPSExtOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPSIToFPOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPSIToFPOpAdaptor {
+public:
+  VPSIToFPOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPSIToFPOpAdaptor(VPSIToFPOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPSIToFPOp : public ::mlir::Op<VPSIToFPOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPSIToFPOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.sitofp");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPSIToFPOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPSRemOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPSRemOpAdaptor {
+public:
+  VPSRemOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPSRemOpAdaptor(VPSRemOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPSRemOp : public ::mlir::Op<VPSRemOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPSRemOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.srem");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPSRemOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPSelectMinOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPSelectMinOpAdaptor {
+public:
+  VPSelectMinOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPSelectMinOpAdaptor(VPSelectMinOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getCond();
+  ::mlir::Value getTrueVal();
+  ::mlir::Value getFalseVal();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPSelectMinOp : public ::mlir::Op<VPSelectMinOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPSelectMinOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.select");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getCond();
+  ::mlir::Value getTrueVal();
+  ::mlir::Value getFalseVal();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getCondMutable();
+  ::mlir::MutableOperandRange getTrueValMutable();
+  ::mlir::MutableOperandRange getFalseValMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value cond, ::mlir::Value true_val, ::mlir::Value false_val, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value cond, ::mlir::Value true_val, ::mlir::Value false_val, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPSelectMinOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPShlOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPShlOpAdaptor {
+public:
+  VPShlOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPShlOpAdaptor(VPShlOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPShlOp : public ::mlir::Op<VPShlOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPShlOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.shl");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPShlOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPStoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPStoreOpAdaptor {
+public:
+  VPStoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPStoreOpAdaptor(VPStoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVal();
+  ::mlir::Value getPtr();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPStoreOp : public ::mlir::Op<VPStoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPStoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.store");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVal();
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getPtrMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value val, ::mlir::Value ptr, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value val, ::mlir::Value ptr, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPStoreOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPStridedLoadOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPStridedLoadOpAdaptor {
+public:
+  VPStridedLoadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPStridedLoadOpAdaptor(VPStridedLoadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::Value getStride();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPStridedLoadOp : public ::mlir::Op<VPStridedLoadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPStridedLoadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.experimental.vp.strided.load");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::TypedValue<::mlir::IntegerType> getStride();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getPtrMutable();
+  ::mlir::MutableOperandRange getStrideMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptr, ::mlir::Value stride, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, ::mlir::Value stride, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPStridedLoadOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPStridedStoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPStridedStoreOpAdaptor {
+public:
+  VPStridedStoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPStridedStoreOpAdaptor(VPStridedStoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVal();
+  ::mlir::Value getPtr();
+  ::mlir::Value getStride();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPStridedStoreOp : public ::mlir::Op<VPStridedStoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<5>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPStridedStoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.experimental.vp.strided.store");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVal();
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::TypedValue<::mlir::IntegerType> getStride();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getPtrMutable();
+  ::mlir::MutableOperandRange getStrideMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value val, ::mlir::Value ptr, ::mlir::Value stride, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value val, ::mlir::Value ptr, ::mlir::Value stride, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPStridedStoreOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPSubOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPSubOpAdaptor {
+public:
+  VPSubOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPSubOpAdaptor(VPSubOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPSubOp : public ::mlir::Op<VPSubOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPSubOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.sub");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPSubOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPTruncOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPTruncOpAdaptor {
+public:
+  VPTruncOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPTruncOpAdaptor(VPTruncOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPTruncOp : public ::mlir::Op<VPTruncOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPTruncOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.trunc");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPTruncOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPUDivOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPUDivOpAdaptor {
+public:
+  VPUDivOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPUDivOpAdaptor(VPUDivOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPUDivOp : public ::mlir::Op<VPUDivOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPUDivOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.udiv");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPUDivOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPUIToFPOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPUIToFPOpAdaptor {
+public:
+  VPUIToFPOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPUIToFPOpAdaptor(VPUIToFPOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPUIToFPOp : public ::mlir::Op<VPUIToFPOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPUIToFPOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.uitofp");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPUIToFPOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPURemOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPURemOpAdaptor {
+public:
+  VPURemOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPURemOpAdaptor(VPURemOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPURemOp : public ::mlir::Op<VPURemOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPURemOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.urem");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPURemOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPXorOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPXorOpAdaptor {
+public:
+  VPXorOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPXorOpAdaptor(VPXorOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPXorOp : public ::mlir::Op<VPXorOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPXorOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.xor");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPXorOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VPZExtOp declarations
+//===----------------------------------------------------------------------===//
+
+class VPZExtOpAdaptor {
+public:
+  VPZExtOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VPZExtOpAdaptor(VPZExtOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::Value getEvl();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VPZExtOp : public ::mlir::Op<VPZExtOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VPZExtOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vp.zext");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrc();
+  ::mlir::Value getMask();
+  ::mlir::TypedValue<::mlir::IntegerType> getEvl();
+  ::mlir::MutableOperandRange getSrcMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getEvlMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value src, ::mlir::Value mask, ::mlir::Value evl);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VPZExtOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VaCopyOp declarations
+//===----------------------------------------------------------------------===//
+
+class VaCopyOpAdaptor {
+public:
+  VaCopyOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VaCopyOpAdaptor(VaCopyOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getDestList();
+  ::mlir::Value getSrcList();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VaCopyOp : public ::mlir::Op<VaCopyOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VaCopyOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vacopy");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getDestList();
+  ::mlir::Value getSrcList();
+  ::mlir::MutableOperandRange getDestListMutable();
+  ::mlir::MutableOperandRange getSrcListMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value dest_list, ::mlir::Value src_list);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dest_list, ::mlir::Value src_list);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VaCopyOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VaEndOp declarations
+//===----------------------------------------------------------------------===//
+
+class VaEndOpAdaptor {
+public:
+  VaEndOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VaEndOpAdaptor(VaEndOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArgList();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VaEndOp : public ::mlir::Op<VaEndOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VaEndOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vaend");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArgList();
+  ::mlir::MutableOperandRange getArgListMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value arg_list);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg_list);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VaEndOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::VaStartOp declarations
+//===----------------------------------------------------------------------===//
+
+class VaStartOpAdaptor {
+public:
+  VaStartOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VaStartOpAdaptor(VaStartOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArgList();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class VaStartOp : public ::mlir::Op<VaStartOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VaStartOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vastart");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArgList();
+  ::mlir::MutableOperandRange getArgListMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value arg_list);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg_list);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::VaStartOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::masked_compressstore declarations
+//===----------------------------------------------------------------------===//
+
+class masked_compressstoreAdaptor {
+public:
+  masked_compressstoreAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  masked_compressstoreAdaptor(masked_compressstore op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class masked_compressstore : public ::mlir::Op<masked_compressstore, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = masked_compressstoreAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.masked.compressstore");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1, ::mlir::Value odsArg_2);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1, ::mlir::Value odsArg_2);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::masked_compressstore)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::masked_expandload declarations
+//===----------------------------------------------------------------------===//
+
+class masked_expandloadAdaptor {
+public:
+  masked_expandloadAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  masked_expandloadAdaptor(masked_expandload op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class masked_expandload : public ::mlir::Op<masked_expandload, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = masked_expandloadAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.masked.expandload");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1, ::mlir::Value odsArg_2);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0, ::mlir::Value odsArg_1, ::mlir::Value odsArg_2);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::masked_expandload)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::masked_gather declarations
+//===----------------------------------------------------------------------===//
+
+class masked_gatherAdaptor {
+public:
+  masked_gatherAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  masked_gatherAdaptor(masked_gather op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtrs();
+  ::mlir::Value getMask();
+  ::mlir::ValueRange getPassThru();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  uint32_t getAlignment();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class masked_gather : public ::mlir::Op<masked_gather, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::AtLeastNOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = masked_gatherAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("alignment")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAlignmentAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAlignmentAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.masked.gather");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getPtrs();
+  ::mlir::Value getMask();
+  ::mlir::Operation::operand_range getPassThru();
+  ::mlir::MutableOperandRange getPtrsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getPassThruMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  uint32_t getAlignment();
+  void setAlignmentAttr(::mlir::IntegerAttr attr);
+  void setAlignment(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptrs, ::mlir::Value mask, ::mlir::ValueRange pass_thru, ::mlir::IntegerAttr alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptrs, ::mlir::Value mask, ::mlir::ValueRange pass_thru, ::mlir::IntegerAttr alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptrs, ::mlir::Value mask, ::mlir::ValueRange pass_thru, uint32_t alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptrs, ::mlir::Value mask, ::mlir::ValueRange pass_thru, uint32_t alignment);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::masked_gather)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::masked_scatter declarations
+//===----------------------------------------------------------------------===//
+
+class masked_scatterAdaptor {
+public:
+  masked_scatterAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  masked_scatterAdaptor(masked_scatter op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::Value getPtrs();
+  ::mlir::Value getMask();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  uint32_t getAlignment();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class masked_scatter : public ::mlir::Op<masked_scatter, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = masked_scatterAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("alignment")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAlignmentAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAlignmentAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.masked.scatter");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::Value getPtrs();
+  ::mlir::Value getMask();
+  ::mlir::MutableOperandRange getValueMutable();
+  ::mlir::MutableOperandRange getPtrsMutable();
+  ::mlir::MutableOperandRange getMaskMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::IntegerAttr getAlignmentAttr();
+  uint32_t getAlignment();
+  void setAlignmentAttr(::mlir::IntegerAttr attr);
+  void setAlignment(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value, ::mlir::Value ptrs, ::mlir::Value mask, ::mlir::IntegerAttr alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value, ::mlir::Value ptrs, ::mlir::Value mask, ::mlir::IntegerAttr alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value, ::mlir::Value ptrs, ::mlir::Value mask, uint32_t alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value, ::mlir::Value ptrs, ::mlir::Value mask, uint32_t alignment);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::masked_scatter)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_extract declarations
+//===----------------------------------------------------------------------===//
+
+class vector_extractAdaptor {
+public:
+  vector_extractAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_extractAdaptor(vector_extract op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrcvec();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getPosAttr();
+  uint64_t getPos();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_extract : public ::mlir::Op<vector_extract, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_extractAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("pos")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getPosAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getPosAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.extract");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrcvec();
+  ::mlir::MutableOperandRange getSrcvecMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getPosAttr();
+  uint64_t getPos();
+  void setPosAttr(::mlir::IntegerAttr attr);
+  void setPos(uint64_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value srcvec, ::mlir::IntegerAttr pos);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value srcvec, ::mlir::IntegerAttr pos);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value srcvec, uint64_t pos);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value srcvec, uint64_t pos);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  uint64_t getVectorBitWidth(Type vector) {
+    return getVectorNumElements(vector).getKnownMinValue() *
+           getVectorElementType(vector).getIntOrFloatBitWidth();
+  }
+  uint64_t getSrcVectorBitWidth() {
+    return getVectorBitWidth(getSrcvec().getType());
+  }
+  uint64_t getResVectorBitWidth() {
+    return getVectorBitWidth(getRes().getType());
+  }
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_extract)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_insert declarations
+//===----------------------------------------------------------------------===//
+
+class vector_insertAdaptor {
+public:
+  vector_insertAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_insertAdaptor(vector_insert op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getSrcvec();
+  ::mlir::Value getDstvec();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getPosAttr();
+  uint64_t getPos();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_insert : public ::mlir::Op<vector_insert, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_insertAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("pos")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getPosAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getPosAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.insert");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getSrcvec();
+  ::mlir::Value getDstvec();
+  ::mlir::MutableOperandRange getSrcvecMutable();
+  ::mlir::MutableOperandRange getDstvecMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getPosAttr();
+  uint64_t getPos();
+  void setPosAttr(::mlir::IntegerAttr attr);
+  void setPos(uint64_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value srcvec, ::mlir::Value dstvec, ::mlir::IntegerAttr pos);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value srcvec, ::mlir::Value dstvec, ::mlir::IntegerAttr pos);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value srcvec, ::mlir::Value dstvec, ::mlir::IntegerAttr pos);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value srcvec, ::mlir::Value dstvec, uint64_t pos);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value srcvec, ::mlir::Value dstvec, uint64_t pos);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value srcvec, ::mlir::Value dstvec, uint64_t pos);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  uint64_t getVectorBitWidth(Type vector) {
+    return getVectorNumElements(vector).getKnownMinValue() *
+           getVectorElementType(vector).getIntOrFloatBitWidth();
+  }
+  uint64_t getSrcVectorBitWidth() {
+    return getVectorBitWidth(getSrcvec().getType());
+  }
+  uint64_t getDstVectorBitWidth() {
+    return getVectorBitWidth(getDstvec().getType());
+  }
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_insert)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_add declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_addAdaptor {
+public:
+  vector_reduce_addAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_addAdaptor(vector_reduce_add op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_add : public ::mlir::Op<vector_reduce_add, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_addAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.add");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_add)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_and declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_andAdaptor {
+public:
+  vector_reduce_andAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_andAdaptor(vector_reduce_and op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_and : public ::mlir::Op<vector_reduce_and, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_andAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.and");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_and)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_fadd declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_faddAdaptor {
+public:
+  vector_reduce_faddAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_faddAdaptor(vector_reduce_fadd op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getStartValue();
+  ::mlir::Value getInput();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::BoolAttr getReassocAttr();
+  bool getReassoc();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_fadd : public ::mlir::Op<vector_reduce_fadd, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_faddAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("reassoc")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getReassocAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getReassocAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.fadd");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::FloatType> getStartValue();
+  ::mlir::Value getInput();
+  ::mlir::MutableOperandRange getStartValueMutable();
+  ::mlir::MutableOperandRange getInputMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::BoolAttr getReassocAttr();
+  bool getReassoc();
+  void setReassocAttr(::mlir::BoolAttr attr);
+  void setReassoc(bool attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value start_value, ::mlir::Value input, ::mlir::BoolAttr reassoc);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value start_value, ::mlir::Value input, ::mlir::BoolAttr reassoc);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value start_value, ::mlir::Value input, bool reassoc = false);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value start_value, ::mlir::Value input, bool reassoc = false);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_fadd)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_fmax declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_fmaxAdaptor {
+public:
+  vector_reduce_fmaxAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_fmaxAdaptor(vector_reduce_fmax op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_fmax : public ::mlir::Op<vector_reduce_fmax, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_fmaxAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.fmax");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_fmax)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_fmin declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_fminAdaptor {
+public:
+  vector_reduce_fminAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_fminAdaptor(vector_reduce_fmin op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_fmin : public ::mlir::Op<vector_reduce_fmin, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_fminAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.fmin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_fmin)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_fmul declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_fmulAdaptor {
+public:
+  vector_reduce_fmulAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_fmulAdaptor(vector_reduce_fmul op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getStartValue();
+  ::mlir::Value getInput();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::BoolAttr getReassocAttr();
+  bool getReassoc();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_fmul : public ::mlir::Op<vector_reduce_fmul, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_fmulAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("reassoc")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getReassocAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getReassocAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.fmul");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::FloatType> getStartValue();
+  ::mlir::Value getInput();
+  ::mlir::MutableOperandRange getStartValueMutable();
+  ::mlir::MutableOperandRange getInputMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::BoolAttr getReassocAttr();
+  bool getReassoc();
+  void setReassocAttr(::mlir::BoolAttr attr);
+  void setReassoc(bool attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value start_value, ::mlir::Value input, ::mlir::BoolAttr reassoc);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value start_value, ::mlir::Value input, ::mlir::BoolAttr reassoc);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value start_value, ::mlir::Value input, bool reassoc = false);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value start_value, ::mlir::Value input, bool reassoc = false);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_fmul)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_mul declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_mulAdaptor {
+public:
+  vector_reduce_mulAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_mulAdaptor(vector_reduce_mul op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_mul : public ::mlir::Op<vector_reduce_mul, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_mulAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.mul");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_mul)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_or declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_orAdaptor {
+public:
+  vector_reduce_orAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_orAdaptor(vector_reduce_or op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_or : public ::mlir::Op<vector_reduce_or, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_orAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.or");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_or)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_smax declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_smaxAdaptor {
+public:
+  vector_reduce_smaxAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_smaxAdaptor(vector_reduce_smax op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_smax : public ::mlir::Op<vector_reduce_smax, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_smaxAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.smax");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_smax)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_smin declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_sminAdaptor {
+public:
+  vector_reduce_sminAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_sminAdaptor(vector_reduce_smin op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_smin : public ::mlir::Op<vector_reduce_smin, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_sminAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.smin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_smin)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_umax declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_umaxAdaptor {
+public:
+  vector_reduce_umaxAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_umaxAdaptor(vector_reduce_umax op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_umax : public ::mlir::Op<vector_reduce_umax, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_umaxAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.umax");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_umax)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_umin declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_uminAdaptor {
+public:
+  vector_reduce_uminAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_uminAdaptor(vector_reduce_umin op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_umin : public ::mlir::Op<vector_reduce_umin, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_uminAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.umin");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_umin)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vector_reduce_xor declarations
+//===----------------------------------------------------------------------===//
+
+class vector_reduce_xorAdaptor {
+public:
+  vector_reduce_xorAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vector_reduce_xorAdaptor(vector_reduce_xor op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vector_reduce_xor : public ::mlir::Op<vector_reduce_xor, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultElementType> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vector_reduce_xorAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vector.reduce.xor");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vector_reduce_xor)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::vscale declarations
+//===----------------------------------------------------------------------===//
+
+class vscaleAdaptor {
+public:
+  vscaleAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  vscaleAdaptor(vscale op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class vscale : public ::mlir::Op<vscale, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = vscaleAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.intr.vscale");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::vscale)
+
+
+#endif  // GET_OP_CLASSES
+

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.h.inc
@@ -1,0 +1,6472 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Op Declarations                                                            *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#if defined(GET_OP_CLASSES) || defined(GET_OP_FWD_DEFINES)
+#undef GET_OP_FWD_DEFINES
+namespace mlir {
+namespace LLVM {
+class AShrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AccessGroupMetadataOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AddOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AddrSpaceCastOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AddressOfOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AliasScopeDomainMetadataOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AliasScopeMetadataOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AllocaOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AndOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AtomicCmpXchgOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class AtomicRMWOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class BitcastOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class BrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CallOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CondBrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ConstantOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ExtractElementOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ExtractValueOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FAddOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FCmpOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FDivOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FMulOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FNegOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FPExtOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FPToSIOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FPToUIOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FPTruncOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FRemOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FSubOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FenceOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class FreezeOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class GEPOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class GlobalCtorsOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class GlobalDtorsOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class GlobalOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ICmpOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class InlineAsmOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class InsertElementOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class InsertValueOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class IntToPtrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class InvokeOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class LLVMFuncOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class LShrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class LandingpadOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class LoadOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MetadataOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class MulOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class NullOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class OrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class PtrToIntOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ResumeOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ReturnOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SDivOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SExtOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SIToFPOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SRemOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SelectOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ShlOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ShuffleVectorOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class StoreOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SubOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class SwitchOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class TruncOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class UDivOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class UIToFPOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class URemOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class UndefOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class UnreachableOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class XOrOp;
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class ZExtOp;
+} // namespace LLVM
+} // namespace mlir
+#endif
+
+#ifdef GET_OP_CLASSES
+#undef GET_OP_CLASSES
+
+
+//===----------------------------------------------------------------------===//
+// Local Utility Method Definitions
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AShrOp declarations
+//===----------------------------------------------------------------------===//
+
+class AShrOpAdaptor {
+public:
+  AShrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AShrOpAdaptor(AShrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AShrOp : public ::mlir::Op<AShrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AShrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.ashr");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AShrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AccessGroupMetadataOp declarations
+//===----------------------------------------------------------------------===//
+
+class AccessGroupMetadataOpAdaptor {
+public:
+  AccessGroupMetadataOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AccessGroupMetadataOpAdaptor(AccessGroupMetadataOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AccessGroupMetadataOp : public ::mlir::Op<AccessGroupMetadataOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::HasParent<MetadataOp>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::SymbolOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AccessGroupMetadataOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("sym_name")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getSymNameAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getSymNameAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.access_group");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  void setSymNameAttr(::mlir::StringAttr attr);
+  void setSymName(::llvm::StringRef attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::StringAttr sym_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::StringAttr sym_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::llvm::StringRef sym_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::llvm::StringRef sym_name);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AccessGroupMetadataOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AddOp declarations
+//===----------------------------------------------------------------------===//
+
+class AddOpAdaptor {
+public:
+  AddOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AddOpAdaptor(AddOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AddOp : public ::mlir::Op<AddOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::OpTrait::IsCommutative, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AddOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.add");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AddOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AddrSpaceCastOp declarations
+//===----------------------------------------------------------------------===//
+
+class AddrSpaceCastOpAdaptor {
+public:
+  AddrSpaceCastOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AddrSpaceCastOpAdaptor(AddrSpaceCastOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AddrSpaceCastOp : public ::mlir::Op<AddrSpaceCastOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AddrSpaceCastOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.addrspacecast");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::OpFoldResult fold(::llvm::ArrayRef<::mlir::Attribute> operands);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AddrSpaceCastOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AddressOfOp declarations
+//===----------------------------------------------------------------------===//
+
+class AddressOfOpAdaptor {
+public:
+  AddressOfOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AddressOfOpAdaptor(AddressOfOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::FlatSymbolRefAttr getGlobalNameAttr();
+  ::llvm::StringRef getGlobalName();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AddressOfOp : public ::mlir::Op<AddressOfOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::LLVM::LLVMPointerType>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::SymbolUserOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AddressOfOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("global_name")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getGlobalNameAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getGlobalNameAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.mlir.addressof");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getRes();
+  ::mlir::FlatSymbolRefAttr getGlobalNameAttr();
+  ::llvm::StringRef getGlobalName();
+  void setGlobalNameAttr(::mlir::FlatSymbolRefAttr attr);
+  void setGlobalName(::llvm::StringRef attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, GlobalOp global, ArrayRef<NamedAttribute> attrs = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, LLVMFuncOp func, ArrayRef<NamedAttribute> attrs = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::FlatSymbolRefAttr global_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::FlatSymbolRefAttr global_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::llvm::StringRef global_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::llvm::StringRef global_name);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verifySymbolUses(::mlir::SymbolTableCollection &symbolTable);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  /// Return the llvm.mlir.global operation that defined the value referenced
+  /// here.
+  GlobalOp getGlobal(SymbolTableCollection &symbolTable);
+
+  /// Return the llvm.func operation that is referenced here.
+  LLVMFuncOp getFunction(SymbolTableCollection &symbolTable);
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AddressOfOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AliasScopeDomainMetadataOp declarations
+//===----------------------------------------------------------------------===//
+
+class AliasScopeDomainMetadataOpAdaptor {
+public:
+  AliasScopeDomainMetadataOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AliasScopeDomainMetadataOpAdaptor(AliasScopeDomainMetadataOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::StringAttr getDescriptionAttr();
+  ::std::optional< ::llvm::StringRef > getDescription();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AliasScopeDomainMetadataOp : public ::mlir::Op<AliasScopeDomainMetadataOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::HasParent<MetadataOp>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::SymbolOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AliasScopeDomainMetadataOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("description"), ::llvm::StringRef("sym_name")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getDescriptionAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getDescriptionAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getSymNameAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getSymNameAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.alias_scope_domain");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::StringAttr getDescriptionAttr();
+  ::std::optional< ::llvm::StringRef > getDescription();
+  void setSymNameAttr(::mlir::StringAttr attr);
+  void setSymName(::llvm::StringRef attrValue);
+  void setDescriptionAttr(::mlir::StringAttr attr);
+  void setDescription(::std::optional<::llvm::StringRef> attrValue);
+  ::mlir::Attribute removeDescriptionAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::StringAttr sym_name, /*optional*/::mlir::StringAttr description);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::StringAttr sym_name, /*optional*/::mlir::StringAttr description);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::llvm::StringRef sym_name, /*optional*/::mlir::StringAttr description);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::llvm::StringRef sym_name, /*optional*/::mlir::StringAttr description);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AliasScopeDomainMetadataOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AliasScopeMetadataOp declarations
+//===----------------------------------------------------------------------===//
+
+class AliasScopeMetadataOpAdaptor {
+public:
+  AliasScopeMetadataOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AliasScopeMetadataOpAdaptor(AliasScopeMetadataOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::FlatSymbolRefAttr getDomainAttr();
+  ::llvm::StringRef getDomain();
+  ::mlir::StringAttr getDescriptionAttr();
+  ::std::optional< ::llvm::StringRef > getDescription();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AliasScopeMetadataOp : public ::mlir::Op<AliasScopeMetadataOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::HasParent<MetadataOp>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::SymbolOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AliasScopeMetadataOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("description"), ::llvm::StringRef("domain"), ::llvm::StringRef("sym_name")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getDescriptionAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getDescriptionAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getDomainAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getDomainAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getSymNameAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getSymNameAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.alias_scope");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::FlatSymbolRefAttr getDomainAttr();
+  ::llvm::StringRef getDomain();
+  ::mlir::StringAttr getDescriptionAttr();
+  ::std::optional< ::llvm::StringRef > getDescription();
+  void setSymNameAttr(::mlir::StringAttr attr);
+  void setSymName(::llvm::StringRef attrValue);
+  void setDomainAttr(::mlir::FlatSymbolRefAttr attr);
+  void setDomain(::llvm::StringRef attrValue);
+  void setDescriptionAttr(::mlir::StringAttr attr);
+  void setDescription(::std::optional<::llvm::StringRef> attrValue);
+  ::mlir::Attribute removeDescriptionAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::StringAttr sym_name, ::mlir::FlatSymbolRefAttr domain, /*optional*/::mlir::StringAttr description);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::StringAttr sym_name, ::mlir::FlatSymbolRefAttr domain, /*optional*/::mlir::StringAttr description);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::llvm::StringRef sym_name, ::llvm::StringRef domain, /*optional*/::mlir::StringAttr description);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::llvm::StringRef sym_name, ::llvm::StringRef domain, /*optional*/::mlir::StringAttr description);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 3 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AliasScopeMetadataOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AllocaOp declarations
+//===----------------------------------------------------------------------===//
+
+class AllocaOpAdaptor {
+public:
+  AllocaOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AllocaOpAdaptor(AllocaOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArraySize();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  ::std::optional<uint64_t> getAlignment();
+  ::mlir::TypeAttr getElemTypeAttr();
+  ::std::optional<::mlir::Type> getElemType();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AllocaOp : public ::mlir::Op<AllocaOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::LLVM::LLVMPointerType>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AllocaOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("alignment"), ::llvm::StringRef("elem_type")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAlignmentAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAlignmentAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getElemTypeAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getElemTypeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.alloca");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getArraySize();
+  ::mlir::MutableOperandRange getArraySizeMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getRes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  ::std::optional<uint64_t> getAlignment();
+  ::mlir::TypeAttr getElemTypeAttr();
+  ::std::optional<::mlir::Type> getElemType();
+  void setAlignmentAttr(::mlir::IntegerAttr attr);
+  void setAlignment(::std::optional<uint64_t> attrValue);
+  void setElemTypeAttr(::mlir::TypeAttr attr);
+  void setElemType(::std::optional<::mlir::Type> attrValue);
+  ::mlir::Attribute removeAlignmentAttr();
+  ::mlir::Attribute removeElemTypeAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, Value arraySize, unsigned alignment);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, Type elementType, Value arraySize, unsigned alignment = 0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arraySize, /*optional*/::mlir::IntegerAttr alignment, /*optional*/::mlir::TypeAttr elem_type);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arraySize, /*optional*/::mlir::IntegerAttr alignment, /*optional*/::mlir::TypeAttr elem_type);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AllocaOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AndOp declarations
+//===----------------------------------------------------------------------===//
+
+class AndOpAdaptor {
+public:
+  AndOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AndOpAdaptor(AndOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AndOp : public ::mlir::Op<AndOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AndOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.and");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AndOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AtomicCmpXchgOp declarations
+//===----------------------------------------------------------------------===//
+
+class AtomicCmpXchgOpAdaptor {
+public:
+  AtomicCmpXchgOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AtomicCmpXchgOpAdaptor(AtomicCmpXchgOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::Value getCmp();
+  ::mlir::Value getVal();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::AtomicOrderingAttr getSuccessOrderingAttr();
+  ::mlir::LLVM::AtomicOrdering getSuccessOrdering();
+  ::mlir::LLVM::AtomicOrderingAttr getFailureOrderingAttr();
+  ::mlir::LLVM::AtomicOrdering getFailureOrdering();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AtomicCmpXchgOp : public ::mlir::Op<AtomicCmpXchgOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AtomicCmpXchgOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("failure_ordering"), ::llvm::StringRef("success_ordering")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFailureOrderingAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFailureOrderingAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getSuccessOrderingAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getSuccessOrderingAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.cmpxchg");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::Value getCmp();
+  ::mlir::Value getVal();
+  ::mlir::MutableOperandRange getPtrMutable();
+  ::mlir::MutableOperandRange getCmpMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::AtomicOrderingAttr getSuccessOrderingAttr();
+  ::mlir::LLVM::AtomicOrdering getSuccessOrdering();
+  ::mlir::LLVM::AtomicOrderingAttr getFailureOrderingAttr();
+  ::mlir::LLVM::AtomicOrdering getFailureOrdering();
+  void setSuccessOrderingAttr(::mlir::LLVM::AtomicOrderingAttr attr);
+  void setSuccessOrdering(::mlir::LLVM::AtomicOrdering attrValue);
+  void setFailureOrderingAttr(::mlir::LLVM::AtomicOrderingAttr attr);
+  void setFailureOrdering(::mlir::LLVM::AtomicOrdering attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptr, ::mlir::Value cmp, ::mlir::Value val, ::mlir::LLVM::AtomicOrderingAttr success_ordering, ::mlir::LLVM::AtomicOrderingAttr failure_ordering);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, ::mlir::Value cmp, ::mlir::Value val, ::mlir::LLVM::AtomicOrderingAttr success_ordering, ::mlir::LLVM::AtomicOrderingAttr failure_ordering);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptr, ::mlir::Value cmp, ::mlir::Value val, ::mlir::LLVM::AtomicOrdering success_ordering, ::mlir::LLVM::AtomicOrdering failure_ordering);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, ::mlir::Value cmp, ::mlir::Value val, ::mlir::LLVM::AtomicOrdering success_ordering, ::mlir::LLVM::AtomicOrdering failure_ordering);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AtomicCmpXchgOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::AtomicRMWOp declarations
+//===----------------------------------------------------------------------===//
+
+class AtomicRMWOpAdaptor {
+public:
+  AtomicRMWOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  AtomicRMWOpAdaptor(AtomicRMWOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::Value getVal();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::AtomicBinOpAttr getBinOpAttr();
+  ::mlir::LLVM::AtomicBinOp getBinOp();
+  ::mlir::LLVM::AtomicOrderingAttr getOrderingAttr();
+  ::mlir::LLVM::AtomicOrdering getOrdering();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class AtomicRMWOp : public ::mlir::Op<AtomicRMWOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = AtomicRMWOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("bin_op"), ::llvm::StringRef("ordering")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getBinOpAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getBinOpAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getOrderingAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getOrderingAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.atomicrmw");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::Value getVal();
+  ::mlir::MutableOperandRange getPtrMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::AtomicBinOpAttr getBinOpAttr();
+  ::mlir::LLVM::AtomicBinOp getBinOp();
+  ::mlir::LLVM::AtomicOrderingAttr getOrderingAttr();
+  ::mlir::LLVM::AtomicOrdering getOrdering();
+  void setBinOpAttr(::mlir::LLVM::AtomicBinOpAttr attr);
+  void setBinOp(::mlir::LLVM::AtomicBinOp attrValue);
+  void setOrderingAttr(::mlir::LLVM::AtomicOrderingAttr attr);
+  void setOrdering(::mlir::LLVM::AtomicOrdering attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::LLVM::AtomicBinOpAttr bin_op, ::mlir::Value ptr, ::mlir::Value val, ::mlir::LLVM::AtomicOrderingAttr ordering);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::LLVM::AtomicBinOpAttr bin_op, ::mlir::Value ptr, ::mlir::Value val, ::mlir::LLVM::AtomicOrderingAttr ordering);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::LLVM::AtomicBinOp bin_op, ::mlir::Value ptr, ::mlir::Value val, ::mlir::LLVM::AtomicOrdering ordering);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::LLVM::AtomicBinOp bin_op, ::mlir::Value ptr, ::mlir::Value val, ::mlir::LLVM::AtomicOrdering ordering);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::AtomicRMWOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::BitcastOp declarations
+//===----------------------------------------------------------------------===//
+
+class BitcastOpAdaptor {
+public:
+  BitcastOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BitcastOpAdaptor(BitcastOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class BitcastOp : public ::mlir::Op<BitcastOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BitcastOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.bitcast");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::OpFoldResult fold(::llvm::ArrayRef<::mlir::Attribute> operands);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::BitcastOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::BrOp declarations
+//===----------------------------------------------------------------------===//
+
+class BrOpAdaptor {
+public:
+  BrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BrOpAdaptor(BrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getDestOperands();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class BrOp : public ::mlir::Op<BrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::OneSuccessor, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants, ::mlir::BranchOpInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::IsTerminator> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.br");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getDestOperands();
+  ::mlir::MutableOperandRange getDestOperandsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Block *getDest();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ValueRange operands, SuccessorRange destinations, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange destOperands, ::mlir::Block *dest);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange destOperands, ::mlir::Block *dest);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::SuccessorOperands getSuccessorOperands(unsigned index);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::BrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CallOp declarations
+//===----------------------------------------------------------------------===//
+
+class CallOpAdaptor {
+public:
+  CallOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CallOpAdaptor(CallOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::FlatSymbolRefAttr getCalleeAttr();
+  ::std::optional< ::llvm::StringRef > getCallee();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CallOp : public ::mlir::Op<CallOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::VariadicResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::CallOpInterface::Trait, ::mlir::SymbolUserOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CallOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("callee"), ::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getCalleeAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getCalleeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.call");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getResult();
+  ::mlir::FlatSymbolRefAttr getCalleeAttr();
+  ::std::optional< ::llvm::StringRef > getCallee();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setCalleeAttr(::mlir::FlatSymbolRefAttr attr);
+  void setCallee(::std::optional<::llvm::StringRef> attrValue);
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  ::mlir::Attribute removeCalleeAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, LLVMFuncOp func, ValueRange args);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, TypeRange results, StringAttr callee, ValueRange args = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, TypeRange results, StringRef callee, ValueRange args = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, /*optional*/::mlir::Type result, /*optional*/::mlir::FlatSymbolRefAttr callee, ::mlir::ValueRange odsArg_0, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, /*optional*/::mlir::FlatSymbolRefAttr callee, ::mlir::ValueRange odsArg_0, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, /*optional*/::mlir::Type result, /*optional*/::mlir::FlatSymbolRefAttr callee, ::mlir::ValueRange odsArg_0, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, /*optional*/::mlir::FlatSymbolRefAttr callee, ::mlir::ValueRange odsArg_0, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::CallInterfaceCallable getCallableForCallee();
+  ::mlir::Operation::operand_range getArgOperands();
+  ::mlir::LogicalResult verifySymbolUses(::mlir::SymbolTableCollection &symbolTable);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CallOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::CondBrOp declarations
+//===----------------------------------------------------------------------===//
+
+class CondBrOpAdaptor {
+public:
+  CondBrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CondBrOpAdaptor(CondBrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getCondition();
+  ::mlir::ValueRange getTrueDestOperands();
+  ::mlir::ValueRange getFalseDestOperands();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::ElementsAttr getBranchWeightsAttr();
+  ::std::optional< ::mlir::ElementsAttr > getBranchWeights();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class CondBrOp : public ::mlir::Op<CondBrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::NSuccessors<2>::Impl, ::mlir::OpTrait::AtLeastNOperands<1>::Impl, ::mlir::OpTrait::AttrSizedOperandSegments, ::mlir::OpTrait::OpInvariants, ::mlir::BranchOpInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::IsTerminator> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CondBrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("branch_weights"), ::llvm::StringRef("operand_segment_sizes")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getBranchWeightsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getBranchWeightsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getOperandSegmentSizesAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getOperandSegmentSizesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.cond_br");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getCondition();
+  ::mlir::Operation::operand_range getTrueDestOperands();
+  ::mlir::Operation::operand_range getFalseDestOperands();
+  ::mlir::MutableOperandRange getConditionMutable();
+  ::mlir::MutableOperandRange getTrueDestOperandsMutable();
+  ::mlir::MutableOperandRange getFalseDestOperandsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Block *getTrueDest();
+  ::mlir::Block *getFalseDest();
+  ::mlir::ElementsAttr getBranchWeightsAttr();
+  ::std::optional< ::mlir::ElementsAttr > getBranchWeights();
+  void setBranchWeightsAttr(::mlir::ElementsAttr attr);
+  ::mlir::Attribute removeBranchWeightsAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value condition, Block *trueDest, ValueRange trueOperands, Block *falseDest, ValueRange falseOperands, Optional<std::pair<uint32_t, uint32_t>> weights = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value condition, Block *trueDest, Block *falseDest, ValueRange falseOperands = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ValueRange operands, SuccessorRange destinations, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value condition, ::mlir::ValueRange trueDestOperands, ::mlir::ValueRange falseDestOperands, /*optional*/::mlir::ElementsAttr branch_weights, ::mlir::Block *trueDest, ::mlir::Block *falseDest);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value condition, ::mlir::ValueRange trueDestOperands, ::mlir::ValueRange falseDestOperands, /*optional*/::mlir::ElementsAttr branch_weights, ::mlir::Block *trueDest, ::mlir::Block *falseDest);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::SuccessorOperands getSuccessorOperands(unsigned index);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CondBrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ConstantOp declarations
+//===----------------------------------------------------------------------===//
+
+class ConstantOpAdaptor {
+public:
+  ConstantOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ConstantOpAdaptor(ConstantOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::Attribute getValueAttr();
+  ::mlir::Attribute getValue();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ConstantOp : public ::mlir::Op<ConstantOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::ConstantLike> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ConstantOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("value")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getValueAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getValueAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.mlir.constant");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::Attribute getValueAttr();
+  ::mlir::Attribute getValue();
+  void setValueAttr(::mlir::Attribute attr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type type, int64_t value);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type type, const APInt &value);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type type, const APFloat &value);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, TypedAttr value);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Attribute value);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Attribute value);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::OpFoldResult fold(::llvm::ArrayRef<::mlir::Attribute> operands);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ConstantOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ExtractElementOp declarations
+//===----------------------------------------------------------------------===//
+
+class ExtractElementOpAdaptor {
+public:
+  ExtractElementOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ExtractElementOpAdaptor(ExtractElementOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVector();
+  ::mlir::Value getPosition();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ExtractElementOp : public ::mlir::Op<ExtractElementOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ExtractElementOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.extractelement");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVector();
+  ::mlir::TypedValue<::mlir::IntegerType> getPosition();
+  ::mlir::MutableOperandRange getVectorMutable();
+  ::mlir::MutableOperandRange getPositionMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value vector, Value position, ArrayRef<NamedAttribute> attrs = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value vector, ::mlir::Value position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value vector, ::mlir::Value position);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ExtractElementOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ExtractValueOp declarations
+//===----------------------------------------------------------------------===//
+
+class ExtractValueOpAdaptor {
+public:
+  ExtractValueOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ExtractValueOpAdaptor(ExtractValueOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getContainer();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::DenseI64ArrayAttr getPositionAttr();
+  ::llvm::ArrayRef<int64_t> getPosition();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ExtractValueOp : public ::mlir::Op<ExtractValueOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ExtractValueOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("position")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getPositionAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getPositionAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.extractvalue");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getContainer();
+  ::mlir::MutableOperandRange getContainerMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::DenseI64ArrayAttr getPositionAttr();
+  ::llvm::ArrayRef<int64_t> getPosition();
+  void setPositionAttr(::mlir::DenseI64ArrayAttr attr);
+  void setPosition(::llvm::ArrayRef<int64_t> attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value container, ArrayRef<int64_t> position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value container, ::mlir::DenseI64ArrayAttr position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value container, ::mlir::DenseI64ArrayAttr position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value container, ::llvm::ArrayRef<int64_t> position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value container, ::llvm::ArrayRef<int64_t> position);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::OpFoldResult fold(::llvm::ArrayRef<::mlir::Attribute> operands);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ExtractValueOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FAddOp declarations
+//===----------------------------------------------------------------------===//
+
+class FAddOpAdaptor {
+public:
+  FAddOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FAddOpAdaptor(FAddOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FAddOp : public ::mlir::Op<FAddOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FAddOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fadd");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FAddOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FCmpOp declarations
+//===----------------------------------------------------------------------===//
+
+class FCmpOpAdaptor {
+public:
+  FCmpOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FCmpOpAdaptor(FCmpOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FCmpPredicateAttr getPredicateAttr();
+  ::mlir::LLVM::FCmpPredicate getPredicate();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FCmpOp : public ::mlir::Op<FCmpOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::OpTrait::SameTypeOperands> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FCmpOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags"), ::llvm::StringRef("predicate")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getPredicateAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getPredicateAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fcmp");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FCmpPredicateAttr getPredicateAttr();
+  ::mlir::LLVM::FCmpPredicate getPredicate();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setPredicateAttr(::mlir::LLVM::FCmpPredicateAttr attr);
+  void setPredicate(::mlir::LLVM::FCmpPredicate attrValue);
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, FCmpPredicate predicate, Value lhs, Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::LLVM::FCmpPredicateAttr predicate, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::LLVM::FCmpPredicateAttr predicate, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::LLVM::FCmpPredicate predicate, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::LLVM::FCmpPredicate predicate, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FCmpOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FDivOp declarations
+//===----------------------------------------------------------------------===//
+
+class FDivOpAdaptor {
+public:
+  FDivOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FDivOpAdaptor(FDivOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FDivOp : public ::mlir::Op<FDivOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FDivOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fdiv");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FDivOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FMulOp declarations
+//===----------------------------------------------------------------------===//
+
+class FMulOpAdaptor {
+public:
+  FMulOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FMulOpAdaptor(FMulOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FMulOp : public ::mlir::Op<FMulOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FMulOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fmul");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FMulOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FNegOp declarations
+//===----------------------------------------------------------------------===//
+
+class FNegOpAdaptor {
+public:
+  FNegOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FNegOpAdaptor(FNegOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getOperand();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FNegOp : public ::mlir::Op<FNegOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FNegOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fneg");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getOperand();
+  ::mlir::MutableOperandRange getOperandMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value operand, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value operand, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value operand, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value operand, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value operand, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value operand, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FNegOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FPExtOp declarations
+//===----------------------------------------------------------------------===//
+
+class FPExtOpAdaptor {
+public:
+  FPExtOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FPExtOpAdaptor(FPExtOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FPExtOp : public ::mlir::Op<FPExtOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FPExtOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fpext");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FPExtOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FPToSIOp declarations
+//===----------------------------------------------------------------------===//
+
+class FPToSIOpAdaptor {
+public:
+  FPToSIOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FPToSIOpAdaptor(FPToSIOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FPToSIOp : public ::mlir::Op<FPToSIOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FPToSIOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fptosi");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FPToSIOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FPToUIOp declarations
+//===----------------------------------------------------------------------===//
+
+class FPToUIOpAdaptor {
+public:
+  FPToUIOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FPToUIOpAdaptor(FPToUIOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FPToUIOp : public ::mlir::Op<FPToUIOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FPToUIOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fptoui");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FPToUIOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FPTruncOp declarations
+//===----------------------------------------------------------------------===//
+
+class FPTruncOpAdaptor {
+public:
+  FPTruncOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FPTruncOpAdaptor(FPTruncOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FPTruncOp : public ::mlir::Op<FPTruncOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FPTruncOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fptrunc");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FPTruncOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FRemOp declarations
+//===----------------------------------------------------------------------===//
+
+class FRemOpAdaptor {
+public:
+  FRemOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FRemOpAdaptor(FRemOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FRemOp : public ::mlir::Op<FRemOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FRemOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.frem");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FRemOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FSubOp declarations
+//===----------------------------------------------------------------------===//
+
+class FSubOpAdaptor {
+public:
+  FSubOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FSubOpAdaptor(FSubOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FSubOp : public ::mlir::Op<FSubOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::LLVM::FastmathFlagsInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FSubOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("fastmathFlags")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getFastmathFlagsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getFastmathFlagsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fsub");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::FastmathFlagsAttr getFastmathFlagsAttr();
+  ::mlir::LLVM::FastmathFlags getFastmathFlags();
+  void setFastmathFlagsAttr(::mlir::LLVM::FastmathFlagsAttr attr);
+  void setFastmathFlags(::mlir::LLVM::FastmathFlags attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlagsAttr fastmathFlags);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs, ::mlir::LLVM::FastmathFlags fastmathFlags = {});
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FSubOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FenceOp declarations
+//===----------------------------------------------------------------------===//
+
+class FenceOpAdaptor {
+public:
+  FenceOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FenceOpAdaptor(FenceOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::AtomicOrderingAttr getOrderingAttr();
+  ::mlir::LLVM::AtomicOrdering getOrdering();
+  ::mlir::StringAttr getSyncscopeAttr();
+  ::llvm::StringRef getSyncscope();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FenceOp : public ::mlir::Op<FenceOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FenceOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("ordering"), ::llvm::StringRef("syncscope")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getOrderingAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getOrderingAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getSyncscopeAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getSyncscopeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.fence");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::LLVM::AtomicOrderingAttr getOrderingAttr();
+  ::mlir::LLVM::AtomicOrdering getOrdering();
+  ::mlir::StringAttr getSyncscopeAttr();
+  ::llvm::StringRef getSyncscope();
+  void setOrderingAttr(::mlir::LLVM::AtomicOrderingAttr attr);
+  void setOrdering(::mlir::LLVM::AtomicOrdering attrValue);
+  void setSyncscopeAttr(::mlir::StringAttr attr);
+  void setSyncscope(::llvm::StringRef attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::LLVM::AtomicOrderingAttr ordering, ::mlir::StringAttr syncscope);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::LLVM::AtomicOrderingAttr ordering, ::mlir::StringAttr syncscope);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::LLVM::AtomicOrdering ordering, ::llvm::StringRef syncscope);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::LLVM::AtomicOrdering ordering, ::llvm::StringRef syncscope);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FenceOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::FreezeOp declarations
+//===----------------------------------------------------------------------===//
+
+class FreezeOpAdaptor {
+public:
+  FreezeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  FreezeOpAdaptor(FreezeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVal();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class FreezeOp : public ::mlir::Op<FreezeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = FreezeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.freeze");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVal();
+  ::mlir::MutableOperandRange getValMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value val);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value val);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value val);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FreezeOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::GEPOp declarations
+//===----------------------------------------------------------------------===//
+
+class GEPOpAdaptor {
+public:
+  GEPOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GEPOpAdaptor(GEPOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getBase();
+  ::mlir::ValueRange getDynamicIndices();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::DenseI32ArrayAttr getRawConstantIndicesAttr();
+  ::llvm::ArrayRef<int32_t> getRawConstantIndices();
+  ::mlir::TypeAttr getElemTypeAttr();
+  ::std::optional<::mlir::Type> getElemType();
+  ::mlir::UnitAttr getInboundsAttr();
+  bool getInbounds();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class GEPOp : public ::mlir::Op<GEPOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::AtLeastNOperands<1>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GEPOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("elem_type"), ::llvm::StringRef("inbounds"), ::llvm::StringRef("rawConstantIndices")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getElemTypeAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getElemTypeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getInboundsAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getInboundsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getRawConstantIndicesAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getRawConstantIndicesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.getelementptr");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getBase();
+  ::mlir::Operation::operand_range getDynamicIndices();
+  ::mlir::MutableOperandRange getBaseMutable();
+  ::mlir::MutableOperandRange getDynamicIndicesMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::DenseI32ArrayAttr getRawConstantIndicesAttr();
+  ::llvm::ArrayRef<int32_t> getRawConstantIndices();
+  ::mlir::TypeAttr getElemTypeAttr();
+  ::std::optional<::mlir::Type> getElemType();
+  ::mlir::UnitAttr getInboundsAttr();
+  bool getInbounds();
+  void setRawConstantIndicesAttr(::mlir::DenseI32ArrayAttr attr);
+  void setRawConstantIndices(::llvm::ArrayRef<int32_t> attrValue);
+  void setElemTypeAttr(::mlir::TypeAttr attr);
+  void setElemType(::std::optional<::mlir::Type> attrValue);
+  void setInboundsAttr(::mlir::UnitAttr attr);
+  void setInbounds(bool attrValue);
+  ::mlir::Attribute removeElemTypeAttr();
+  ::mlir::Attribute removeInboundsAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, Type basePtrType, Value basePtr, ValueRange indices, bool inbounds = false, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, Value basePtr, ValueRange indices, bool inbounds = false, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, Value basePtr, ArrayRef<GEPArg> indices, bool inbounds = false, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, Type basePtrType, Value basePtr, ArrayRef<GEPArg> indices, bool inbounds = false, ArrayRef<NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::OpFoldResult fold(::llvm::ArrayRef<::mlir::Attribute> operands);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 3 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  constexpr static int32_t kDynamicIndex = std::numeric_limits<int32_t>::min();
+
+  /// Returns the type pointed to by the pointer argument of this GEP.
+  Type getSourceElementType();
+
+  GEPIndicesAdaptor<ValueRange> getIndices();
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::GEPOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::GlobalCtorsOp declarations
+//===----------------------------------------------------------------------===//
+
+class GlobalCtorsOpAdaptor {
+public:
+  GlobalCtorsOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GlobalCtorsOpAdaptor(GlobalCtorsOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::ArrayAttr getCtorsAttr();
+  ::mlir::ArrayAttr getCtors();
+  ::mlir::ArrayAttr getPrioritiesAttr();
+  ::mlir::ArrayAttr getPriorities();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class GlobalCtorsOp : public ::mlir::Op<GlobalCtorsOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::SymbolUserOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GlobalCtorsOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("ctors"), ::llvm::StringRef("priorities")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getCtorsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getCtorsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getPrioritiesAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getPrioritiesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.mlir.global_ctors");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::ArrayAttr getCtorsAttr();
+  ::mlir::ArrayAttr getCtors();
+  ::mlir::ArrayAttr getPrioritiesAttr();
+  ::mlir::ArrayAttr getPriorities();
+  void setCtorsAttr(::mlir::ArrayAttr attr);
+  void setPrioritiesAttr(::mlir::ArrayAttr attr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ArrayAttr ctors, ::mlir::ArrayAttr priorities);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ArrayAttr ctors, ::mlir::ArrayAttr priorities);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::LogicalResult verifySymbolUses(::mlir::SymbolTableCollection &symbolTable);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::GlobalCtorsOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::GlobalDtorsOp declarations
+//===----------------------------------------------------------------------===//
+
+class GlobalDtorsOpAdaptor {
+public:
+  GlobalDtorsOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GlobalDtorsOpAdaptor(GlobalDtorsOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::ArrayAttr getDtorsAttr();
+  ::mlir::ArrayAttr getDtors();
+  ::mlir::ArrayAttr getPrioritiesAttr();
+  ::mlir::ArrayAttr getPriorities();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class GlobalDtorsOp : public ::mlir::Op<GlobalDtorsOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::SymbolUserOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GlobalDtorsOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("dtors"), ::llvm::StringRef("priorities")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getDtorsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getDtorsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getPrioritiesAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getPrioritiesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.mlir.global_dtors");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::ArrayAttr getDtorsAttr();
+  ::mlir::ArrayAttr getDtors();
+  ::mlir::ArrayAttr getPrioritiesAttr();
+  ::mlir::ArrayAttr getPriorities();
+  void setDtorsAttr(::mlir::ArrayAttr attr);
+  void setPrioritiesAttr(::mlir::ArrayAttr attr);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ArrayAttr dtors, ::mlir::ArrayAttr priorities);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ArrayAttr dtors, ::mlir::ArrayAttr priorities);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::LogicalResult verifySymbolUses(::mlir::SymbolTableCollection &symbolTable);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::GlobalDtorsOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::GlobalOp declarations
+//===----------------------------------------------------------------------===//
+
+class GlobalOpAdaptor {
+public:
+  GlobalOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GlobalOpAdaptor(GlobalOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::TypeAttr getGlobalTypeAttr();
+  ::mlir::Type getGlobalType();
+  ::mlir::UnitAttr getConstantAttr();
+  bool getConstant();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::LLVM::LinkageAttr getLinkageAttr();
+  ::mlir::LLVM::Linkage getLinkage();
+  ::mlir::UnitAttr getDsoLocalAttr();
+  bool getDsoLocal();
+  ::mlir::UnitAttr getThreadLocal_Attr();
+  bool getThreadLocal_();
+  ::mlir::Attribute getValueAttr();
+  ::std::optional<::mlir::Attribute> getValue();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  ::std::optional<uint64_t> getAlignment();
+  ::mlir::IntegerAttr getAddrSpaceAttr();
+  uint32_t getAddrSpace();
+  ::mlir::LLVM::UnnamedAddrAttr getUnnamedAddrAttr();
+  ::std::optional<::mlir::LLVM::UnnamedAddr> getUnnamedAddr();
+  ::mlir::StringAttr getSectionAttr();
+  ::std::optional< ::llvm::StringRef > getSection();
+  ::mlir::Region &getInitializer();
+  ::mlir::RegionRange getRegions();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class GlobalOp : public ::mlir::Op<GlobalOp, ::mlir::OpTrait::OneRegion, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::SingleBlockImplicitTerminator<ReturnOp>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::IsIsolatedFromAbove, ::mlir::SymbolOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GlobalOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("addr_space"), ::llvm::StringRef("alignment"), ::llvm::StringRef("constant"), ::llvm::StringRef("dso_local"), ::llvm::StringRef("global_type"), ::llvm::StringRef("linkage"), ::llvm::StringRef("section"), ::llvm::StringRef("sym_name"), ::llvm::StringRef("thread_local_"), ::llvm::StringRef("unnamed_addr"), ::llvm::StringRef("value")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAddrSpaceAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAddrSpaceAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getAlignmentAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getAlignmentAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getConstantAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getConstantAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getDsoLocalAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getDsoLocalAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getGlobalTypeAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getGlobalTypeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  ::mlir::StringAttr getLinkageAttrName() {
+    return getAttributeNameForIndex(5);
+  }
+
+  static ::mlir::StringAttr getLinkageAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 5);
+  }
+
+  ::mlir::StringAttr getSectionAttrName() {
+    return getAttributeNameForIndex(6);
+  }
+
+  static ::mlir::StringAttr getSectionAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 6);
+  }
+
+  ::mlir::StringAttr getSymNameAttrName() {
+    return getAttributeNameForIndex(7);
+  }
+
+  static ::mlir::StringAttr getSymNameAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 7);
+  }
+
+  ::mlir::StringAttr getThreadLocal_AttrName() {
+    return getAttributeNameForIndex(8);
+  }
+
+  static ::mlir::StringAttr getThreadLocal_AttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 8);
+  }
+
+  ::mlir::StringAttr getUnnamedAddrAttrName() {
+    return getAttributeNameForIndex(9);
+  }
+
+  static ::mlir::StringAttr getUnnamedAddrAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 9);
+  }
+
+  ::mlir::StringAttr getValueAttrName() {
+    return getAttributeNameForIndex(10);
+  }
+
+  static ::mlir::StringAttr getValueAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 10);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.mlir.global");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Region &getInitializer();
+  ::mlir::TypeAttr getGlobalTypeAttr();
+  ::mlir::Type getGlobalType();
+  ::mlir::UnitAttr getConstantAttr();
+  bool getConstant();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::LLVM::LinkageAttr getLinkageAttr();
+  ::mlir::LLVM::Linkage getLinkage();
+  ::mlir::UnitAttr getDsoLocalAttr();
+  bool getDsoLocal();
+  ::mlir::UnitAttr getThreadLocal_Attr();
+  bool getThreadLocal_();
+  ::mlir::Attribute getValueAttr();
+  ::std::optional<::mlir::Attribute> getValue();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  ::std::optional<uint64_t> getAlignment();
+  ::mlir::IntegerAttr getAddrSpaceAttr();
+  uint32_t getAddrSpace();
+  ::mlir::LLVM::UnnamedAddrAttr getUnnamedAddrAttr();
+  ::std::optional<::mlir::LLVM::UnnamedAddr> getUnnamedAddr();
+  ::mlir::StringAttr getSectionAttr();
+  ::std::optional< ::llvm::StringRef > getSection();
+  void setGlobalTypeAttr(::mlir::TypeAttr attr);
+  void setGlobalType(::mlir::Type attrValue);
+  void setConstantAttr(::mlir::UnitAttr attr);
+  void setConstant(bool attrValue);
+  void setSymNameAttr(::mlir::StringAttr attr);
+  void setSymName(::llvm::StringRef attrValue);
+  void setLinkageAttr(::mlir::LLVM::LinkageAttr attr);
+  void setLinkage(::mlir::LLVM::Linkage attrValue);
+  void setDsoLocalAttr(::mlir::UnitAttr attr);
+  void setDsoLocal(bool attrValue);
+  void setThreadLocal_Attr(::mlir::UnitAttr attr);
+  void setThreadLocal_(bool attrValue);
+  void setValueAttr(::mlir::Attribute attr);
+  void setAlignmentAttr(::mlir::IntegerAttr attr);
+  void setAlignment(::std::optional<uint64_t> attrValue);
+  void setAddrSpaceAttr(::mlir::IntegerAttr attr);
+  void setAddrSpace(uint32_t attrValue);
+  void setUnnamedAddrAttr(::mlir::LLVM::UnnamedAddrAttr attr);
+  void setUnnamedAddr(::std::optional<::mlir::LLVM::UnnamedAddr> attrValue);
+  void setSectionAttr(::mlir::StringAttr attr);
+  void setSection(::std::optional<::llvm::StringRef> attrValue);
+  ::mlir::Attribute removeConstantAttr();
+  ::mlir::Attribute removeDsoLocalAttr();
+  ::mlir::Attribute removeThreadLocal_Attr();
+  ::mlir::Attribute removeValueAttr();
+  ::mlir::Attribute removeAlignmentAttr();
+  ::mlir::Attribute removeUnnamedAddrAttr();
+  ::mlir::Attribute removeSectionAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type type, bool isConstant, Linkage linkage, StringRef name, Attribute value, uint64_t alignment = 0, unsigned addrSpace = 0, bool dsoLocal = false, bool thread_local_ = false, ArrayRef<NamedAttribute> attrs = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeAttr global_type, /*optional*/::mlir::UnitAttr constant, ::mlir::StringAttr sym_name, ::mlir::LLVM::LinkageAttr linkage, /*optional*/::mlir::UnitAttr dso_local, /*optional*/::mlir::UnitAttr thread_local_, /*optional*/::mlir::Attribute value, /*optional*/::mlir::IntegerAttr alignment, ::mlir::IntegerAttr addr_space, /*optional*/::mlir::LLVM::UnnamedAddrAttr unnamed_addr, /*optional*/::mlir::StringAttr section);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::TypeAttr global_type, /*optional*/::mlir::UnitAttr constant, ::mlir::StringAttr sym_name, ::mlir::LLVM::LinkageAttr linkage, /*optional*/::mlir::UnitAttr dso_local, /*optional*/::mlir::UnitAttr thread_local_, /*optional*/::mlir::Attribute value, /*optional*/::mlir::IntegerAttr alignment, ::mlir::IntegerAttr addr_space, /*optional*/::mlir::LLVM::UnnamedAddrAttr unnamed_addr, /*optional*/::mlir::StringAttr section);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type global_type, /*optional*/bool constant, ::llvm::StringRef sym_name, ::mlir::LLVM::Linkage linkage, /*optional*/bool dso_local, /*optional*/bool thread_local_, /*optional*/::mlir::Attribute value, /*optional*/::mlir::IntegerAttr alignment, uint32_t addr_space, /*optional*/::mlir::LLVM::UnnamedAddrAttr unnamed_addr, /*optional*/::mlir::StringAttr section);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Type global_type, /*optional*/bool constant, ::llvm::StringRef sym_name, ::mlir::LLVM::Linkage linkage, /*optional*/bool dso_local, /*optional*/bool thread_local_, /*optional*/::mlir::Attribute value, /*optional*/::mlir::IntegerAttr alignment, uint32_t addr_space, /*optional*/::mlir::LLVM::UnnamedAddrAttr unnamed_addr, /*optional*/::mlir::StringAttr section);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::LogicalResult verifyRegions();
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 11 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  /// Return the LLVM type of the global.
+  Type getType() {
+    return getGlobalType();
+  }
+  /// Return the initializer attribute if it exists, or a null attribute.
+  Attribute getValueOrNull() {
+    return getValue().value_or(Attribute());
+  }
+  /// Return the initializer region. This may be empty, but if it is not it
+  /// terminates in an `llvm.return` op with the initializer value.
+  Region &getInitializerRegion() {
+    return getOperation()->getRegion(0);
+  }
+  /// Return the initializer block. If the initializer region is empty this
+  /// is nullptr. If it is not nullptr, it terminates with an `llvm.return`
+  /// op with the initializer value.
+  Block *getInitializerBlock() {
+    return getInitializerRegion().empty() ?
+      nullptr : &getInitializerRegion().front();
+  }
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::GlobalOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ICmpOp declarations
+//===----------------------------------------------------------------------===//
+
+class ICmpOpAdaptor {
+public:
+  ICmpOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ICmpOpAdaptor(ICmpOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LLVM::ICmpPredicateAttr getPredicateAttr();
+  ::mlir::LLVM::ICmpPredicate getPredicate();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ICmpOp : public ::mlir::Op<ICmpOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameTypeOperands> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ICmpOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("predicate")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getPredicateAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getPredicateAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.icmp");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::LLVM::ICmpPredicateAttr getPredicateAttr();
+  ::mlir::LLVM::ICmpPredicate getPredicate();
+  void setPredicateAttr(::mlir::LLVM::ICmpPredicateAttr attr);
+  void setPredicate(::mlir::LLVM::ICmpPredicate attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ICmpPredicate predicate, Value lhs, Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::LLVM::ICmpPredicateAttr predicate, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::LLVM::ICmpPredicateAttr predicate, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::LLVM::ICmpPredicate predicate, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::LLVM::ICmpPredicate predicate, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ICmpOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::InlineAsmOp declarations
+//===----------------------------------------------------------------------===//
+
+class InlineAsmOpAdaptor {
+public:
+  InlineAsmOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  InlineAsmOpAdaptor(InlineAsmOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::StringAttr getAsmStringAttr();
+  ::llvm::StringRef getAsmString();
+  ::mlir::StringAttr getConstraintsAttr();
+  ::llvm::StringRef getConstraints();
+  ::mlir::UnitAttr getHasSideEffectsAttr();
+  bool getHasSideEffects();
+  ::mlir::UnitAttr getIsAlignStackAttr();
+  bool getIsAlignStack();
+  ::mlir::LLVM::AsmDialectAttr getAsmDialectAttr();
+  ::std::optional<::mlir::LLVM::AsmDialect> getAsmDialect();
+  ::mlir::ArrayAttr getOperandAttrsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getOperandAttrs();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class InlineAsmOp : public ::mlir::Op<InlineAsmOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::VariadicResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = InlineAsmOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("asm_dialect"), ::llvm::StringRef("asm_string"), ::llvm::StringRef("constraints"), ::llvm::StringRef("has_side_effects"), ::llvm::StringRef("is_align_stack"), ::llvm::StringRef("operand_attrs")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAsmDialectAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAsmDialectAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getAsmStringAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getAsmStringAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getConstraintsAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getConstraintsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getHasSideEffectsAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getHasSideEffectsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getIsAlignStackAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getIsAlignStackAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  ::mlir::StringAttr getOperandAttrsAttrName() {
+    return getAttributeNameForIndex(5);
+  }
+
+  static ::mlir::StringAttr getOperandAttrsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 5);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.inline_asm");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getOperands();
+  ::mlir::MutableOperandRange getOperandsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::StringAttr getAsmStringAttr();
+  ::llvm::StringRef getAsmString();
+  ::mlir::StringAttr getConstraintsAttr();
+  ::llvm::StringRef getConstraints();
+  ::mlir::UnitAttr getHasSideEffectsAttr();
+  bool getHasSideEffects();
+  ::mlir::UnitAttr getIsAlignStackAttr();
+  bool getIsAlignStack();
+  ::mlir::LLVM::AsmDialectAttr getAsmDialectAttr();
+  ::std::optional<::mlir::LLVM::AsmDialect> getAsmDialect();
+  ::mlir::ArrayAttr getOperandAttrsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getOperandAttrs();
+  void setAsmStringAttr(::mlir::StringAttr attr);
+  void setAsmString(::llvm::StringRef attrValue);
+  void setConstraintsAttr(::mlir::StringAttr attr);
+  void setConstraints(::llvm::StringRef attrValue);
+  void setHasSideEffectsAttr(::mlir::UnitAttr attr);
+  void setHasSideEffects(bool attrValue);
+  void setIsAlignStackAttr(::mlir::UnitAttr attr);
+  void setIsAlignStack(bool attrValue);
+  void setAsmDialectAttr(::mlir::LLVM::AsmDialectAttr attr);
+  void setAsmDialect(::std::optional<::mlir::LLVM::AsmDialect> attrValue);
+  void setOperandAttrsAttr(::mlir::ArrayAttr attr);
+  ::mlir::Attribute removeHasSideEffectsAttr();
+  ::mlir::Attribute removeIsAlignStackAttr();
+  ::mlir::Attribute removeAsmDialectAttr();
+  ::mlir::Attribute removeOperandAttrsAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, /*optional*/::mlir::Type res, ::mlir::ValueRange operands, ::mlir::StringAttr asm_string, ::mlir::StringAttr constraints, /*optional*/::mlir::UnitAttr has_side_effects, /*optional*/::mlir::UnitAttr is_align_stack, /*optional*/::mlir::LLVM::AsmDialectAttr asm_dialect, /*optional*/::mlir::ArrayAttr operand_attrs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::mlir::StringAttr asm_string, ::mlir::StringAttr constraints, /*optional*/::mlir::UnitAttr has_side_effects, /*optional*/::mlir::UnitAttr is_align_stack, /*optional*/::mlir::LLVM::AsmDialectAttr asm_dialect, /*optional*/::mlir::ArrayAttr operand_attrs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, /*optional*/::mlir::Type res, ::mlir::ValueRange operands, ::llvm::StringRef asm_string, ::llvm::StringRef constraints, /*optional*/bool has_side_effects, /*optional*/bool is_align_stack, /*optional*/::mlir::LLVM::AsmDialectAttr asm_dialect, /*optional*/::mlir::ArrayAttr operand_attrs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::StringRef asm_string, ::llvm::StringRef constraints, /*optional*/bool has_side_effects, /*optional*/bool is_align_stack, /*optional*/::mlir::LLVM::AsmDialectAttr asm_dialect, /*optional*/::mlir::ArrayAttr operand_attrs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 6 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  static StringRef getElementTypeAttrName() {
+    return "elementtype";
+  }
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::InlineAsmOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::InsertElementOp declarations
+//===----------------------------------------------------------------------===//
+
+class InsertElementOpAdaptor {
+public:
+  InsertElementOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  InsertElementOpAdaptor(InsertElementOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVector();
+  ::mlir::Value getValue();
+  ::mlir::Value getPosition();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class InsertElementOp : public ::mlir::Op<InsertElementOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = InsertElementOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.insertelement");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVector();
+  ::mlir::Value getValue();
+  ::mlir::TypedValue<::mlir::IntegerType> getPosition();
+  ::mlir::MutableOperandRange getVectorMutable();
+  ::mlir::MutableOperandRange getValueMutable();
+  ::mlir::MutableOperandRange getPositionMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value vector, ::mlir::Value value, ::mlir::Value position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value vector, ::mlir::Value value, ::mlir::Value position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value vector, ::mlir::Value value, ::mlir::Value position);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::InsertElementOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::InsertValueOp declarations
+//===----------------------------------------------------------------------===//
+
+class InsertValueOpAdaptor {
+public:
+  InsertValueOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  InsertValueOpAdaptor(InsertValueOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getContainer();
+  ::mlir::Value getValue();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::DenseI64ArrayAttr getPositionAttr();
+  ::llvm::ArrayRef<int64_t> getPosition();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class InsertValueOp : public ::mlir::Op<InsertValueOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = InsertValueOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("position")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getPositionAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getPositionAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.insertvalue");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getContainer();
+  ::mlir::Value getValue();
+  ::mlir::MutableOperandRange getContainerMutable();
+  ::mlir::MutableOperandRange getValueMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::DenseI64ArrayAttr getPositionAttr();
+  ::llvm::ArrayRef<int64_t> getPosition();
+  void setPositionAttr(::mlir::DenseI64ArrayAttr attr);
+  void setPosition(::llvm::ArrayRef<int64_t> attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value container, ::mlir::Value value, ::mlir::DenseI64ArrayAttr position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value container, ::mlir::Value value, ::mlir::DenseI64ArrayAttr position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value container, ::mlir::Value value, ::mlir::DenseI64ArrayAttr position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value container, ::mlir::Value value, ::llvm::ArrayRef<int64_t> position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value container, ::mlir::Value value, ::llvm::ArrayRef<int64_t> position);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value container, ::mlir::Value value, ::llvm::ArrayRef<int64_t> position);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::InsertValueOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::IntToPtrOp declarations
+//===----------------------------------------------------------------------===//
+
+class IntToPtrOpAdaptor {
+public:
+  IntToPtrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  IntToPtrOpAdaptor(IntToPtrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class IntToPtrOp : public ::mlir::Op<IntToPtrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = IntToPtrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.inttoptr");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::IntToPtrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::InvokeOp declarations
+//===----------------------------------------------------------------------===//
+
+class InvokeOpAdaptor {
+public:
+  InvokeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  InvokeOpAdaptor(InvokeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getCalleeOperands();
+  ::mlir::ValueRange getNormalDestOperands();
+  ::mlir::ValueRange getUnwindDestOperands();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::FlatSymbolRefAttr getCalleeAttr();
+  ::std::optional< ::llvm::StringRef > getCallee();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class InvokeOp : public ::mlir::Op<InvokeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::VariadicResults, ::mlir::OpTrait::NSuccessors<2>::Impl, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::AttrSizedOperandSegments, ::mlir::OpTrait::OpInvariants, ::mlir::BranchOpInterface::Trait, ::mlir::CallOpInterface::Trait, ::mlir::OpTrait::IsTerminator> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = InvokeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("callee"), ::llvm::StringRef("operand_segment_sizes")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getCalleeAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getCalleeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getOperandSegmentSizesAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getOperandSegmentSizesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.invoke");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getCalleeOperands();
+  ::mlir::Operation::operand_range getNormalDestOperands();
+  ::mlir::Operation::operand_range getUnwindDestOperands();
+  ::mlir::MutableOperandRange getCalleeOperandsMutable();
+  ::mlir::MutableOperandRange getNormalDestOperandsMutable();
+  ::mlir::MutableOperandRange getUnwindDestOperandsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Block *getNormalDest();
+  ::mlir::Block *getUnwindDest();
+  ::mlir::FlatSymbolRefAttr getCalleeAttr();
+  ::std::optional< ::llvm::StringRef > getCallee();
+  void setCalleeAttr(::mlir::FlatSymbolRefAttr attr);
+  void setCallee(::std::optional<::llvm::StringRef> attrValue);
+  ::mlir::Attribute removeCalleeAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, TypeRange tys, FlatSymbolRefAttr callee, ValueRange ops, Block*normal, ValueRange normalOps, Block*unwind, ValueRange unwindOps);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, TypeRange tys, ValueRange ops, Block*normal, ValueRange normalOps, Block*unwind, ValueRange unwindOps);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultType0, /*optional*/::mlir::FlatSymbolRefAttr callee, ::mlir::ValueRange callee_operands, ::mlir::ValueRange normalDestOperands, ::mlir::ValueRange unwindDestOperands, ::mlir::Block *normalDest, ::mlir::Block *unwindDest);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::SuccessorOperands getSuccessorOperands(unsigned index);
+  ::mlir::CallInterfaceCallable getCallableForCallee();
+  ::mlir::Operation::operand_range getArgOperands();
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::InvokeOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::LLVMFuncOp declarations
+//===----------------------------------------------------------------------===//
+
+class LLVMFuncOpAdaptor {
+public:
+  LLVMFuncOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LLVMFuncOpAdaptor(LLVMFuncOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::TypeAttr getFunctionTypeAttr();
+  ::mlir::LLVM::LLVMFunctionType getFunctionType();
+  ::mlir::LLVM::LinkageAttr getLinkageAttr();
+  ::mlir::LLVM::Linkage getLinkage();
+  ::mlir::UnitAttr getDsoLocalAttr();
+  bool getDsoLocal();
+  ::mlir::LLVM::CConvAttr getCConvAttr();
+  ::mlir::LLVM::cconv::CConv getCConv();
+  ::mlir::FlatSymbolRefAttr getPersonalityAttr();
+  ::std::optional< ::llvm::StringRef > getPersonality();
+  ::mlir::StringAttr getGarbageCollectorAttr();
+  ::std::optional< ::llvm::StringRef > getGarbageCollector();
+  ::mlir::ArrayAttr getPassthroughAttr();
+  ::std::optional< ::mlir::ArrayAttr > getPassthrough();
+  ::mlir::ArrayAttr getArgAttrsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getArgAttrs();
+  ::mlir::ArrayAttr getResAttrsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getResAttrs();
+  ::mlir::Region &getBody();
+  ::mlir::RegionRange getRegions();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class LLVMFuncOp : public ::mlir::Op<LLVMFuncOp, ::mlir::OpTrait::OneRegion, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::AutomaticAllocationScope, ::mlir::OpTrait::IsIsolatedFromAbove, ::mlir::FunctionOpInterface::Trait, ::mlir::CallableOpInterface::Trait, ::mlir::SymbolOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LLVMFuncOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("CConv"), ::llvm::StringRef("arg_attrs"), ::llvm::StringRef("dso_local"), ::llvm::StringRef("function_type"), ::llvm::StringRef("garbageCollector"), ::llvm::StringRef("linkage"), ::llvm::StringRef("passthrough"), ::llvm::StringRef("personality"), ::llvm::StringRef("res_attrs"), ::llvm::StringRef("sym_name")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getCConvAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getCConvAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getArgAttrsAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getArgAttrsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getDsoLocalAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getDsoLocalAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getFunctionTypeAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getFunctionTypeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getGarbageCollectorAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getGarbageCollectorAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  ::mlir::StringAttr getLinkageAttrName() {
+    return getAttributeNameForIndex(5);
+  }
+
+  static ::mlir::StringAttr getLinkageAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 5);
+  }
+
+  ::mlir::StringAttr getPassthroughAttrName() {
+    return getAttributeNameForIndex(6);
+  }
+
+  static ::mlir::StringAttr getPassthroughAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 6);
+  }
+
+  ::mlir::StringAttr getPersonalityAttrName() {
+    return getAttributeNameForIndex(7);
+  }
+
+  static ::mlir::StringAttr getPersonalityAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 7);
+  }
+
+  ::mlir::StringAttr getResAttrsAttrName() {
+    return getAttributeNameForIndex(8);
+  }
+
+  static ::mlir::StringAttr getResAttrsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 8);
+  }
+
+  ::mlir::StringAttr getSymNameAttrName() {
+    return getAttributeNameForIndex(9);
+  }
+
+  static ::mlir::StringAttr getSymNameAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 9);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.func");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Region &getBody();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::TypeAttr getFunctionTypeAttr();
+  ::mlir::LLVM::LLVMFunctionType getFunctionType();
+  ::mlir::LLVM::LinkageAttr getLinkageAttr();
+  ::mlir::LLVM::Linkage getLinkage();
+  ::mlir::UnitAttr getDsoLocalAttr();
+  bool getDsoLocal();
+  ::mlir::LLVM::CConvAttr getCConvAttr();
+  ::mlir::LLVM::cconv::CConv getCConv();
+  ::mlir::FlatSymbolRefAttr getPersonalityAttr();
+  ::std::optional< ::llvm::StringRef > getPersonality();
+  ::mlir::StringAttr getGarbageCollectorAttr();
+  ::std::optional< ::llvm::StringRef > getGarbageCollector();
+  ::mlir::ArrayAttr getPassthroughAttr();
+  ::std::optional< ::mlir::ArrayAttr > getPassthrough();
+  ::mlir::ArrayAttr getArgAttrsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getArgAttrs();
+  ::mlir::ArrayAttr getResAttrsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getResAttrs();
+  void setSymNameAttr(::mlir::StringAttr attr);
+  void setSymName(::llvm::StringRef attrValue);
+  void setFunctionTypeAttr(::mlir::TypeAttr attr);
+  void setFunctionType(::mlir::LLVM::LLVMFunctionType attrValue);
+  void setLinkageAttr(::mlir::LLVM::LinkageAttr attr);
+  void setLinkage(::mlir::LLVM::Linkage attrValue);
+  void setDsoLocalAttr(::mlir::UnitAttr attr);
+  void setDsoLocal(bool attrValue);
+  void setCConvAttr(::mlir::LLVM::CConvAttr attr);
+  void setCConv(::mlir::LLVM::cconv::CConv attrValue);
+  void setPersonalityAttr(::mlir::FlatSymbolRefAttr attr);
+  void setPersonality(::std::optional<::llvm::StringRef> attrValue);
+  void setGarbageCollectorAttr(::mlir::StringAttr attr);
+  void setGarbageCollector(::std::optional<::llvm::StringRef> attrValue);
+  void setPassthroughAttr(::mlir::ArrayAttr attr);
+  void setArgAttrsAttr(::mlir::ArrayAttr attr);
+  void setResAttrsAttr(::mlir::ArrayAttr attr);
+  ::mlir::Attribute removeDsoLocalAttr();
+  ::mlir::Attribute removePersonalityAttr();
+  ::mlir::Attribute removeGarbageCollectorAttr();
+  ::mlir::Attribute removePassthroughAttr();
+  ::mlir::Attribute removeArgAttrsAttr();
+  ::mlir::Attribute removeResAttrsAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, StringRef name, Type type, Linkage linkage = Linkage::External, bool dsoLocal = false, CConv cconv = CConv::C, ArrayRef<NamedAttribute> attrs = {}, ArrayRef<DictionaryAttr> argAttrs = {});
+  static void populateDefaultAttrs(const ::mlir::RegisteredOperationName &opName, ::mlir::NamedAttrList &attributes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::LogicalResult verifyRegions();
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 10 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  // Add an entry block to an empty function, and set up the block arguments
+  // to match the signature of the function.
+  Block *addEntryBlock();
+
+  bool isVarArg() { return getFunctionType().isVarArg(); }
+
+  /// Returns the argument types of this function.
+  ArrayRef<Type> getArgumentTypes() { return getFunctionType().getParams(); }
+
+  /// Returns the result types of this function.
+  ArrayRef<Type> getResultTypes() { return getFunctionType().getReturnTypes(); }
+
+  /// Returns the callable region, which is the function body. If the function
+  /// is external, returns null.
+  Region *getCallableRegion();
+
+  /// Returns the callable result type, which is the function return type.
+  ArrayRef<Type> getCallableResults() { return getFunctionType().getReturnTypes(); }
+
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LLVMFuncOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::LShrOp declarations
+//===----------------------------------------------------------------------===//
+
+class LShrOpAdaptor {
+public:
+  LShrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LShrOpAdaptor(LShrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class LShrOp : public ::mlir::Op<LShrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LShrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.lshr");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LShrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::LandingpadOp declarations
+//===----------------------------------------------------------------------===//
+
+class LandingpadOpAdaptor {
+public:
+  LandingpadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LandingpadOpAdaptor(LandingpadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::UnitAttr getCleanupAttr();
+  bool getCleanup();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class LandingpadOp : public ::mlir::Op<LandingpadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LandingpadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("cleanup")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getCleanupAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getCleanupAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.landingpad");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::UnitAttr getCleanupAttr();
+  bool getCleanup();
+  void setCleanupAttr(::mlir::UnitAttr attr);
+  void setCleanup(bool attrValue);
+  ::mlir::Attribute removeCleanupAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, /*optional*/::mlir::UnitAttr cleanup, ::mlir::ValueRange odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, /*optional*/::mlir::UnitAttr cleanup, ::mlir::ValueRange odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, /*optional*/bool cleanup, ::mlir::ValueRange odsArg_0);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, /*optional*/bool cleanup, ::mlir::ValueRange odsArg_0);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LandingpadOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::LoadOp declarations
+//===----------------------------------------------------------------------===//
+
+class LoadOpAdaptor {
+public:
+  LoadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LoadOpAdaptor(LoadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getAddr();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::ArrayAttr getAccessGroupsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getAccessGroups();
+  ::mlir::ArrayAttr getAliasScopesAttr();
+  ::std::optional< ::mlir::ArrayAttr > getAliasScopes();
+  ::mlir::ArrayAttr getNoaliasScopesAttr();
+  ::std::optional< ::mlir::ArrayAttr > getNoaliasScopes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  ::std::optional<uint64_t> getAlignment();
+  ::mlir::UnitAttr getVolatile_Attr();
+  bool getVolatile_();
+  ::mlir::UnitAttr getNontemporalAttr();
+  bool getNontemporal();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class LoadOp : public ::mlir::Op<LoadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LoadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("access_groups"), ::llvm::StringRef("alias_scopes"), ::llvm::StringRef("alignment"), ::llvm::StringRef("noalias_scopes"), ::llvm::StringRef("nontemporal"), ::llvm::StringRef("volatile_")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAccessGroupsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAccessGroupsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getAliasScopesAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getAliasScopesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getAlignmentAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getAlignmentAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getNoaliasScopesAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getNoaliasScopesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getNontemporalAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getNontemporalAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  ::mlir::StringAttr getVolatile_AttrName() {
+    return getAttributeNameForIndex(5);
+  }
+
+  static ::mlir::StringAttr getVolatile_AttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 5);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.load");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getAddr();
+  ::mlir::MutableOperandRange getAddrMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::ArrayAttr getAccessGroupsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getAccessGroups();
+  ::mlir::ArrayAttr getAliasScopesAttr();
+  ::std::optional< ::mlir::ArrayAttr > getAliasScopes();
+  ::mlir::ArrayAttr getNoaliasScopesAttr();
+  ::std::optional< ::mlir::ArrayAttr > getNoaliasScopes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  ::std::optional<uint64_t> getAlignment();
+  ::mlir::UnitAttr getVolatile_Attr();
+  bool getVolatile_();
+  ::mlir::UnitAttr getNontemporalAttr();
+  bool getNontemporal();
+  void setAccessGroupsAttr(::mlir::ArrayAttr attr);
+  void setAliasScopesAttr(::mlir::ArrayAttr attr);
+  void setNoaliasScopesAttr(::mlir::ArrayAttr attr);
+  void setAlignmentAttr(::mlir::IntegerAttr attr);
+  void setAlignment(::std::optional<uint64_t> attrValue);
+  void setVolatile_Attr(::mlir::UnitAttr attr);
+  void setVolatile_(bool attrValue);
+  void setNontemporalAttr(::mlir::UnitAttr attr);
+  void setNontemporal(bool attrValue);
+  ::mlir::Attribute removeAccessGroupsAttr();
+  ::mlir::Attribute removeAliasScopesAttr();
+  ::mlir::Attribute removeNoaliasScopesAttr();
+  ::mlir::Attribute removeAlignmentAttr();
+  ::mlir::Attribute removeVolatile_Attr();
+  ::mlir::Attribute removeNontemporalAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value addr, unsigned alignment = 0, bool isVolatile = false, bool isNonTemporal = false);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type t, Value addr, unsigned alignment = 0, bool isVolatile = false, bool isNonTemporal = false);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value addr, /*optional*/::mlir::ArrayAttr access_groups, /*optional*/::mlir::ArrayAttr alias_scopes, /*optional*/::mlir::ArrayAttr noalias_scopes, /*optional*/::mlir::IntegerAttr alignment, /*optional*/::mlir::UnitAttr volatile_, /*optional*/::mlir::UnitAttr nontemporal);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value addr, /*optional*/::mlir::ArrayAttr access_groups, /*optional*/::mlir::ArrayAttr alias_scopes, /*optional*/::mlir::ArrayAttr noalias_scopes, /*optional*/::mlir::IntegerAttr alignment, /*optional*/::mlir::UnitAttr volatile_, /*optional*/::mlir::UnitAttr nontemporal);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value addr, /*optional*/::mlir::ArrayAttr access_groups, /*optional*/::mlir::ArrayAttr alias_scopes, /*optional*/::mlir::ArrayAttr noalias_scopes, /*optional*/::mlir::IntegerAttr alignment, /*optional*/bool volatile_ = false, /*optional*/bool nontemporal = false);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value addr, /*optional*/::mlir::ArrayAttr access_groups, /*optional*/::mlir::ArrayAttr alias_scopes, /*optional*/::mlir::ArrayAttr noalias_scopes, /*optional*/::mlir::IntegerAttr alignment, /*optional*/bool volatile_ = false, /*optional*/bool nontemporal = false);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 6 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LoadOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MetadataOp declarations
+//===----------------------------------------------------------------------===//
+
+class MetadataOpAdaptor {
+public:
+  MetadataOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MetadataOpAdaptor(MetadataOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  ::mlir::Region &getBody();
+  ::mlir::RegionRange getRegions();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MetadataOp : public ::mlir::Op<MetadataOp, ::mlir::OpTrait::OneRegion, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::NoRegionArguments, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::SymbolTable, ::mlir::SymbolOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MetadataOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("sym_name")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getSymNameAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getSymNameAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.metadata");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Region &getBody();
+  ::mlir::StringAttr getSymNameAttr();
+  ::llvm::StringRef getSymName();
+  void setSymNameAttr(::mlir::StringAttr attr);
+  void setSymName(::llvm::StringRef attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::StringAttr sym_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::StringAttr sym_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::llvm::StringRef sym_name);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::llvm::StringRef sym_name);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MetadataOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::MulOp declarations
+//===----------------------------------------------------------------------===//
+
+class MulOpAdaptor {
+public:
+  MulOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MulOpAdaptor(MulOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class MulOp : public ::mlir::Op<MulOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::OpTrait::IsCommutative, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MulOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.mul");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::MulOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::NullOp declarations
+//===----------------------------------------------------------------------===//
+
+class NullOpAdaptor {
+public:
+  NullOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  NullOpAdaptor(NullOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class NullOp : public ::mlir::Op<NullOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::LLVM::LLVMPointerType>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = NullOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.mlir.null");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::NullOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::OrOp declarations
+//===----------------------------------------------------------------------===//
+
+class OrOpAdaptor {
+public:
+  OrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  OrOpAdaptor(OrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class OrOp : public ::mlir::Op<OrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = OrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.or");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::OrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::PtrToIntOp declarations
+//===----------------------------------------------------------------------===//
+
+class PtrToIntOpAdaptor {
+public:
+  PtrToIntOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  PtrToIntOpAdaptor(PtrToIntOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class PtrToIntOp : public ::mlir::Op<PtrToIntOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = PtrToIntOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.ptrtoint");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::PtrToIntOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ResumeOp declarations
+//===----------------------------------------------------------------------===//
+
+class ResumeOpAdaptor {
+public:
+  ResumeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ResumeOpAdaptor(ResumeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ResumeOp : public ::mlir::Op<ResumeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::IsTerminator> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ResumeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.resume");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::MutableOperandRange getValueMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ResumeOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ReturnOp declarations
+//===----------------------------------------------------------------------===//
+
+class ReturnOpAdaptor {
+public:
+  ReturnOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ReturnOpAdaptor(ReturnOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ReturnOp : public ::mlir::Op<ReturnOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::ReturnLike, ::mlir::OpTrait::IsTerminator> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ReturnOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.return");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ValueRange args);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, /*optional*/::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, /*optional*/::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ReturnOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SDivOp declarations
+//===----------------------------------------------------------------------===//
+
+class SDivOpAdaptor {
+public:
+  SDivOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SDivOpAdaptor(SDivOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SDivOp : public ::mlir::Op<SDivOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SDivOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.sdiv");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SDivOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SExtOp declarations
+//===----------------------------------------------------------------------===//
+
+class SExtOpAdaptor {
+public:
+  SExtOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SExtOpAdaptor(SExtOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SExtOp : public ::mlir::Op<SExtOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SExtOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.sext");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SExtOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SIToFPOp declarations
+//===----------------------------------------------------------------------===//
+
+class SIToFPOpAdaptor {
+public:
+  SIToFPOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SIToFPOpAdaptor(SIToFPOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SIToFPOp : public ::mlir::Op<SIToFPOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SIToFPOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.sitofp");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SIToFPOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SRemOp declarations
+//===----------------------------------------------------------------------===//
+
+class SRemOpAdaptor {
+public:
+  SRemOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SRemOpAdaptor(SRemOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SRemOp : public ::mlir::Op<SRemOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SRemOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.srem");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SRemOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SelectOp declarations
+//===----------------------------------------------------------------------===//
+
+class SelectOpAdaptor {
+public:
+  SelectOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SelectOpAdaptor(SelectOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getCondition();
+  ::mlir::Value getTrueValue();
+  ::mlir::Value getFalseValue();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SelectOp : public ::mlir::Op<SelectOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<3>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SelectOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.select");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getCondition();
+  ::mlir::Value getTrueValue();
+  ::mlir::Value getFalseValue();
+  ::mlir::MutableOperandRange getConditionMutable();
+  ::mlir::MutableOperandRange getTrueValueMutable();
+  ::mlir::MutableOperandRange getFalseValueMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value condition, ::mlir::Value trueValue, ::mlir::Value falseValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value condition, ::mlir::Value trueValue, ::mlir::Value falseValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value condition, ::mlir::Value trueValue, ::mlir::Value falseValue);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SelectOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ShlOp declarations
+//===----------------------------------------------------------------------===//
+
+class ShlOpAdaptor {
+public:
+  ShlOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ShlOpAdaptor(ShlOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ShlOp : public ::mlir::Op<ShlOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ShlOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.shl");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ShlOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ShuffleVectorOp declarations
+//===----------------------------------------------------------------------===//
+
+class ShuffleVectorOpAdaptor {
+public:
+  ShuffleVectorOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ShuffleVectorOpAdaptor(ShuffleVectorOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getV1();
+  ::mlir::Value getV2();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::DenseI32ArrayAttr getMaskAttr();
+  ::llvm::ArrayRef<int32_t> getMask();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ShuffleVectorOp : public ::mlir::Op<ShuffleVectorOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ShuffleVectorOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("mask")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getMaskAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getMaskAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.shufflevector");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getV1();
+  ::mlir::Value getV2();
+  ::mlir::MutableOperandRange getV1Mutable();
+  ::mlir::MutableOperandRange getV2Mutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::DenseI32ArrayAttr getMaskAttr();
+  ::llvm::ArrayRef<int32_t> getMask();
+  void setMaskAttr(::mlir::DenseI32ArrayAttr attr);
+  void setMask(::llvm::ArrayRef<int32_t> attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value v1, Value v2, DenseI32ArrayAttr mask, ArrayRef<NamedAttribute> attrs = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value v1, Value v2, ArrayRef<int32_t> mask);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value v1, ::mlir::Value v2, ::mlir::DenseI32ArrayAttr mask);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value v1, ::mlir::Value v2, ::mlir::DenseI32ArrayAttr mask);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value v1, ::mlir::Value v2, ::llvm::ArrayRef<int32_t> mask);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value v1, ::mlir::Value v2, ::llvm::ArrayRef<int32_t> mask);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ShuffleVectorOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::StoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class StoreOpAdaptor {
+public:
+  StoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  StoreOpAdaptor(StoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::Value getAddr();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::ArrayAttr getAccessGroupsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getAccessGroups();
+  ::mlir::ArrayAttr getAliasScopesAttr();
+  ::std::optional< ::mlir::ArrayAttr > getAliasScopes();
+  ::mlir::ArrayAttr getNoaliasScopesAttr();
+  ::std::optional< ::mlir::ArrayAttr > getNoaliasScopes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  ::std::optional<uint64_t> getAlignment();
+  ::mlir::UnitAttr getVolatile_Attr();
+  bool getVolatile_();
+  ::mlir::UnitAttr getNontemporalAttr();
+  bool getNontemporal();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class StoreOp : public ::mlir::Op<StoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = StoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("access_groups"), ::llvm::StringRef("alias_scopes"), ::llvm::StringRef("alignment"), ::llvm::StringRef("noalias_scopes"), ::llvm::StringRef("nontemporal"), ::llvm::StringRef("volatile_")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getAccessGroupsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getAccessGroupsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getAliasScopesAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getAliasScopesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getAlignmentAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getAlignmentAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getNoaliasScopesAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getNoaliasScopesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getNontemporalAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getNontemporalAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  ::mlir::StringAttr getVolatile_AttrName() {
+    return getAttributeNameForIndex(5);
+  }
+
+  static ::mlir::StringAttr getVolatile_AttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 5);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.store");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getAddr();
+  ::mlir::MutableOperandRange getValueMutable();
+  ::mlir::MutableOperandRange getAddrMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::ArrayAttr getAccessGroupsAttr();
+  ::std::optional< ::mlir::ArrayAttr > getAccessGroups();
+  ::mlir::ArrayAttr getAliasScopesAttr();
+  ::std::optional< ::mlir::ArrayAttr > getAliasScopes();
+  ::mlir::ArrayAttr getNoaliasScopesAttr();
+  ::std::optional< ::mlir::ArrayAttr > getNoaliasScopes();
+  ::mlir::IntegerAttr getAlignmentAttr();
+  ::std::optional<uint64_t> getAlignment();
+  ::mlir::UnitAttr getVolatile_Attr();
+  bool getVolatile_();
+  ::mlir::UnitAttr getNontemporalAttr();
+  bool getNontemporal();
+  void setAccessGroupsAttr(::mlir::ArrayAttr attr);
+  void setAliasScopesAttr(::mlir::ArrayAttr attr);
+  void setNoaliasScopesAttr(::mlir::ArrayAttr attr);
+  void setAlignmentAttr(::mlir::IntegerAttr attr);
+  void setAlignment(::std::optional<uint64_t> attrValue);
+  void setVolatile_Attr(::mlir::UnitAttr attr);
+  void setVolatile_(bool attrValue);
+  void setNontemporalAttr(::mlir::UnitAttr attr);
+  void setNontemporal(bool attrValue);
+  ::mlir::Attribute removeAccessGroupsAttr();
+  ::mlir::Attribute removeAliasScopesAttr();
+  ::mlir::Attribute removeNoaliasScopesAttr();
+  ::mlir::Attribute removeAlignmentAttr();
+  ::mlir::Attribute removeVolatile_Attr();
+  ::mlir::Attribute removeNontemporalAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value value, Value addr, unsigned alignment = 0, bool isVolatile = false, bool isNonTemporal = false);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value, ::mlir::Value addr, /*optional*/::mlir::ArrayAttr access_groups, /*optional*/::mlir::ArrayAttr alias_scopes, /*optional*/::mlir::ArrayAttr noalias_scopes, /*optional*/::mlir::IntegerAttr alignment, /*optional*/::mlir::UnitAttr volatile_, /*optional*/::mlir::UnitAttr nontemporal);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value, ::mlir::Value addr, /*optional*/::mlir::ArrayAttr access_groups, /*optional*/::mlir::ArrayAttr alias_scopes, /*optional*/::mlir::ArrayAttr noalias_scopes, /*optional*/::mlir::IntegerAttr alignment, /*optional*/::mlir::UnitAttr volatile_, /*optional*/::mlir::UnitAttr nontemporal);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value, ::mlir::Value addr, /*optional*/::mlir::ArrayAttr access_groups, /*optional*/::mlir::ArrayAttr alias_scopes, /*optional*/::mlir::ArrayAttr noalias_scopes, /*optional*/::mlir::IntegerAttr alignment, /*optional*/bool volatile_ = false, /*optional*/bool nontemporal = false);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value, ::mlir::Value addr, /*optional*/::mlir::ArrayAttr access_groups, /*optional*/::mlir::ArrayAttr alias_scopes, /*optional*/::mlir::ArrayAttr noalias_scopes, /*optional*/::mlir::IntegerAttr alignment, /*optional*/bool volatile_ = false, /*optional*/bool nontemporal = false);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 6 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::StoreOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SubOp declarations
+//===----------------------------------------------------------------------===//
+
+class SubOpAdaptor {
+public:
+  SubOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SubOpAdaptor(SubOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SubOp : public ::mlir::Op<SubOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SubOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.sub");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SubOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::SwitchOp declarations
+//===----------------------------------------------------------------------===//
+
+class SwitchOpAdaptor {
+public:
+  SwitchOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SwitchOpAdaptor(SwitchOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getValue();
+  ::mlir::ValueRange getDefaultOperands();
+  ::llvm::SmallVector<::mlir::ValueRange> getCaseOperands();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::ElementsAttr getCaseValuesAttr();
+  ::std::optional< ::mlir::ElementsAttr > getCaseValues();
+  ::mlir::DenseI32ArrayAttr getCaseOperandSegmentsAttr();
+  ::llvm::ArrayRef<int32_t> getCaseOperandSegments();
+  ::mlir::ElementsAttr getBranchWeightsAttr();
+  ::std::optional< ::mlir::ElementsAttr > getBranchWeights();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class SwitchOp : public ::mlir::Op<SwitchOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::AtLeastNSuccessors<1>::Impl, ::mlir::OpTrait::AtLeastNOperands<1>::Impl, ::mlir::OpTrait::AttrSizedOperandSegments, ::mlir::OpTrait::OpInvariants, ::mlir::BranchOpInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::IsTerminator> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SwitchOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("branch_weights"), ::llvm::StringRef("case_operand_segments"), ::llvm::StringRef("case_values"), ::llvm::StringRef("operand_segment_sizes")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getBranchWeightsAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getBranchWeightsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getCaseOperandSegmentsAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getCaseOperandSegmentsAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getCaseValuesAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getCaseValuesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getOperandSegmentSizesAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getOperandSegmentSizesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.switch");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getValue();
+  ::mlir::Operation::operand_range getDefaultOperands();
+  ::mlir::OperandRangeRange getCaseOperands();
+  ::mlir::MutableOperandRange getValueMutable();
+  ::mlir::MutableOperandRange getDefaultOperandsMutable();
+  ::mlir::MutableOperandRangeRange getCaseOperandsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Block *getDefaultDestination();
+  ::mlir::SuccessorRange getCaseDestinations();
+  ::mlir::ElementsAttr getCaseValuesAttr();
+  ::std::optional< ::mlir::ElementsAttr > getCaseValues();
+  ::mlir::DenseI32ArrayAttr getCaseOperandSegmentsAttr();
+  ::llvm::ArrayRef<int32_t> getCaseOperandSegments();
+  ::mlir::ElementsAttr getBranchWeightsAttr();
+  ::std::optional< ::mlir::ElementsAttr > getBranchWeights();
+  void setCaseValuesAttr(::mlir::ElementsAttr attr);
+  void setCaseOperandSegmentsAttr(::mlir::DenseI32ArrayAttr attr);
+  void setCaseOperandSegments(::llvm::ArrayRef<int32_t> attrValue);
+  void setBranchWeightsAttr(::mlir::ElementsAttr attr);
+  ::mlir::Attribute removeCaseValuesAttr();
+  ::mlir::Attribute removeBranchWeightsAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Value value, Block *defaultDestination, ValueRange defaultOperands, ArrayRef<int32_t> caseValues = {}, BlockRange caseDestinations = {}, ArrayRef<ValueRange> caseOperands = {}, ArrayRef<int32_t> branchWeights = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ValueRange operands, SuccessorRange destinations, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value value, ::mlir::ValueRange defaultOperands, ::llvm::ArrayRef<::mlir::ValueRange> caseOperands, /*optional*/::mlir::ElementsAttr case_values, /*optional*/::mlir::ElementsAttr branch_weights, ::mlir::Block *defaultDestination, ::mlir::BlockRange caseDestinations);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value value, ::mlir::ValueRange defaultOperands, ::llvm::ArrayRef<::mlir::ValueRange> caseOperands, /*optional*/::mlir::ElementsAttr case_values, /*optional*/::mlir::ElementsAttr branch_weights, ::mlir::Block *defaultDestination, ::mlir::BlockRange caseDestinations);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  ::mlir::SuccessorOperands getSuccessorOperands(unsigned index);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 4 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  /// Return the operands for the case destination block at the given index.
+  OperandRange getCaseOperands(unsigned index) {
+    return getCaseOperands()[index];
+  }
+
+  /// Return a mutable range of operands for the case destination block at the
+  /// given index.
+  MutableOperandRange getCaseOperandsMutable(unsigned index) {
+    return getCaseOperandsMutable()[index];
+  }
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::SwitchOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::TruncOp declarations
+//===----------------------------------------------------------------------===//
+
+class TruncOpAdaptor {
+public:
+  TruncOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  TruncOpAdaptor(TruncOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class TruncOp : public ::mlir::Op<TruncOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = TruncOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.trunc");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::TruncOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::UDivOp declarations
+//===----------------------------------------------------------------------===//
+
+class UDivOpAdaptor {
+public:
+  UDivOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UDivOpAdaptor(UDivOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UDivOp : public ::mlir::Op<UDivOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UDivOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.udiv");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::UDivOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::UIToFPOp declarations
+//===----------------------------------------------------------------------===//
+
+class UIToFPOpAdaptor {
+public:
+  UIToFPOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UIToFPOpAdaptor(UIToFPOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UIToFPOp : public ::mlir::Op<UIToFPOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UIToFPOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.uitofp");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::UIToFPOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::URemOp declarations
+//===----------------------------------------------------------------------===//
+
+class URemOpAdaptor {
+public:
+  URemOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  URemOpAdaptor(URemOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class URemOp : public ::mlir::Op<URemOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = URemOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.urem");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::URemOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::UndefOp declarations
+//===----------------------------------------------------------------------===//
+
+class UndefOpAdaptor {
+public:
+  UndefOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UndefOpAdaptor(UndefOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UndefOp : public ::mlir::Op<UndefOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UndefOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.mlir.undef");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::UndefOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::UnreachableOp declarations
+//===----------------------------------------------------------------------===//
+
+class UnreachableOpAdaptor {
+public:
+  UnreachableOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UnreachableOpAdaptor(UnreachableOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UnreachableOp : public ::mlir::Op<UnreachableOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::IsTerminator> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UnreachableOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.unreachable");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::UnreachableOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::XOrOp declarations
+//===----------------------------------------------------------------------===//
+
+class XOrOpAdaptor {
+public:
+  XOrOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  XOrOpAdaptor(XOrOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class XOrOp : public ::mlir::Op<XOrOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait, ::mlir::OpTrait::SameOperandsAndResultType, ::mlir::InferTypeOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = XOrOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.xor");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getLhs();
+  ::mlir::Value getRhs();
+  ::mlir::MutableOperandRange getLhsMutable();
+  ::mlir::MutableOperandRange getRhsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value lhs, ::mlir::Value rhs);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::XOrOp)
+
+namespace mlir {
+namespace LLVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::LLVM::ZExtOp declarations
+//===----------------------------------------------------------------------===//
+
+class ZExtOpAdaptor {
+public:
+  ZExtOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ZExtOpAdaptor(ZExtOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ZExtOp : public ::mlir::Op<ZExtOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ZExtOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("llvm.zext");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operands, ArrayRef<NamedAttribute> attributes = {});
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::ZExtOp)
+
+
+#endif  // GET_OP_CLASSES
+

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.h.inc
@@ -1,0 +1,337 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* AttrDef Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifdef GET_ATTRDEF_CLASSES
+#undef GET_ATTRDEF_CLASSES
+
+
+namespace mlir {
+class AsmParser;
+class AsmPrinter;
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class CConvAttr;
+class DIBasicTypeAttr;
+class DICompileUnitAttr;
+class DICompositeTypeAttr;
+class DIDerivedTypeAttr;
+class DIFileAttr;
+class DILexicalBlockAttr;
+class DILexicalBlockFileAttr;
+class DILocalVariableAttr;
+class DISubprogramAttr;
+class DISubrangeAttr;
+class DISubroutineTypeAttr;
+class FastmathFlagsAttr;
+class LinkageAttr;
+class LoopOptionsAttr;
+namespace detail {
+struct CConvAttrStorage;
+} // namespace detail
+class CConvAttr : public ::mlir::Attribute::AttrBase<CConvAttr, ::mlir::Attribute, detail::CConvAttrStorage> {
+public:
+  using Base::Base;
+  static CConvAttr get(::mlir::MLIRContext *context, CConv CallingConv);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"cconv"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  CConv getCallingConv() const;
+};
+namespace detail {
+struct DIBasicTypeAttrStorage;
+} // namespace detail
+class DIBasicTypeAttr : public ::mlir::Attribute::AttrBase<DIBasicTypeAttr, DITypeAttr, detail::DIBasicTypeAttrStorage> {
+public:
+  using Base::Base;
+  static DIBasicTypeAttr get(::mlir::MLIRContext *context, unsigned tag, StringAttr name, uint64_t sizeInBits, unsigned encoding);
+  static DIBasicTypeAttr get(::mlir::MLIRContext *context, unsigned tag, const Twine &name, uint64_t sizeInBits, unsigned encoding);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_basic_type"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  unsigned getTag() const;
+  StringAttr getName() const;
+  uint64_t getSizeInBits() const;
+  unsigned getEncoding() const;
+};
+namespace detail {
+struct DICompileUnitAttrStorage;
+} // namespace detail
+class DICompileUnitAttr : public ::mlir::Attribute::AttrBase<DICompileUnitAttr, DIScopeAttr, detail::DICompileUnitAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static DICompileUnitAttr get(::mlir::MLIRContext *context, unsigned sourceLanguage, DIFileAttr file, StringAttr producer, bool isOptimized, DIEmissionKind emissionKind);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_compile_unit"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  unsigned getSourceLanguage() const;
+  DIFileAttr getFile() const;
+  StringAttr getProducer() const;
+  bool getIsOptimized() const;
+  DIEmissionKind getEmissionKind() const;
+};
+namespace detail {
+struct DICompositeTypeAttrStorage;
+} // namespace detail
+class DICompositeTypeAttr : public ::mlir::Attribute::AttrBase<DICompositeTypeAttr, DITypeAttr, detail::DICompositeTypeAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static DICompositeTypeAttr get(::mlir::MLIRContext *context, unsigned tag, StringAttr name, DIFileAttr file, uint32_t line, DIScopeAttr scope, DITypeAttr baseType, DIFlags flags, uint64_t sizeInBits, uint64_t alignInBits, ::llvm::ArrayRef<DINodeAttr> elements);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_composite_type"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  unsigned getTag() const;
+  StringAttr getName() const;
+  DIFileAttr getFile() const;
+  uint32_t getLine() const;
+  DIScopeAttr getScope() const;
+  DITypeAttr getBaseType() const;
+  DIFlags getFlags() const;
+  uint64_t getSizeInBits() const;
+  uint64_t getAlignInBits() const;
+  ::llvm::ArrayRef<DINodeAttr> getElements() const;
+};
+namespace detail {
+struct DIDerivedTypeAttrStorage;
+} // namespace detail
+class DIDerivedTypeAttr : public ::mlir::Attribute::AttrBase<DIDerivedTypeAttr, DITypeAttr, detail::DIDerivedTypeAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static DIDerivedTypeAttr get(::mlir::MLIRContext *context, unsigned tag, StringAttr name, DITypeAttr baseType, uint64_t sizeInBits, uint32_t alignInBits, uint64_t offsetInBits);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_derived_type"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  unsigned getTag() const;
+  StringAttr getName() const;
+  DITypeAttr getBaseType() const;
+  uint64_t getSizeInBits() const;
+  uint32_t getAlignInBits() const;
+  uint64_t getOffsetInBits() const;
+};
+namespace detail {
+struct DIFileAttrStorage;
+} // namespace detail
+class DIFileAttr : public ::mlir::Attribute::AttrBase<DIFileAttr, DIScopeAttr, detail::DIFileAttrStorage> {
+public:
+  using Base::Base;
+  static DIFileAttr get(::mlir::MLIRContext *context, StringAttr name, StringAttr directory);
+  static DIFileAttr get(::mlir::MLIRContext *context, StringRef name, StringRef directory);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_file"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  StringAttr getName() const;
+  StringAttr getDirectory() const;
+};
+namespace detail {
+struct DILexicalBlockAttrStorage;
+} // namespace detail
+class DILexicalBlockAttr : public ::mlir::Attribute::AttrBase<DILexicalBlockAttr, DIScopeAttr, detail::DILexicalBlockAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static DILexicalBlockAttr get(::mlir::MLIRContext *context, DIScopeAttr scope, DIFileAttr file, unsigned line, unsigned column);
+  static DILexicalBlockAttr get(DIScopeAttr scope, DIFileAttr file, unsigned line, unsigned column);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_lexical_block"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  DIScopeAttr getScope() const;
+  DIFileAttr getFile() const;
+  unsigned getLine() const;
+  unsigned getColumn() const;
+};
+namespace detail {
+struct DILexicalBlockFileAttrStorage;
+} // namespace detail
+class DILexicalBlockFileAttr : public ::mlir::Attribute::AttrBase<DILexicalBlockFileAttr, DIScopeAttr, detail::DILexicalBlockFileAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static DILexicalBlockFileAttr get(::mlir::MLIRContext *context, DIScopeAttr scope, DIFileAttr file, unsigned discriminator);
+  static DILexicalBlockFileAttr get(DIScopeAttr scope, DIFileAttr file, unsigned discriminator);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_lexical_block_file"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  DIScopeAttr getScope() const;
+  DIFileAttr getFile() const;
+  unsigned getDiscriminator() const;
+};
+namespace detail {
+struct DILocalVariableAttrStorage;
+} // namespace detail
+class DILocalVariableAttr : public ::mlir::Attribute::AttrBase<DILocalVariableAttr, DINodeAttr, detail::DILocalVariableAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static DILocalVariableAttr get(::mlir::MLIRContext *context, DIScopeAttr scope, StringAttr name, DIFileAttr file, unsigned line, unsigned arg, unsigned alignInBits, DITypeAttr type);
+  static DILocalVariableAttr get(DIScopeAttr scope, StringRef name, DIFileAttr file, unsigned line, unsigned arg, unsigned alignInBits, DITypeAttr type);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_local_variable"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  DIScopeAttr getScope() const;
+  StringAttr getName() const;
+  DIFileAttr getFile() const;
+  unsigned getLine() const;
+  unsigned getArg() const;
+  unsigned getAlignInBits() const;
+  DITypeAttr getType() const;
+};
+namespace detail {
+struct DISubprogramAttrStorage;
+} // namespace detail
+class DISubprogramAttr : public ::mlir::Attribute::AttrBase<DISubprogramAttr, DIScopeAttr, detail::DISubprogramAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static DISubprogramAttr get(::mlir::MLIRContext *context, DICompileUnitAttr compileUnit, DIScopeAttr scope, StringAttr name, StringAttr linkageName, DIFileAttr file, unsigned line, unsigned scopeLine, DISubprogramFlags subprogramFlags, DISubroutineTypeAttr type);
+  static DISubprogramAttr get(DICompileUnitAttr compileUnit, DIScopeAttr scope, StringRef name, StringRef linkageName, DIFileAttr file, unsigned line, unsigned scopeLine, DISubprogramFlags subprogramFlags, DISubroutineTypeAttr type);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_subprogram"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  DICompileUnitAttr getCompileUnit() const;
+  DIScopeAttr getScope() const;
+  StringAttr getName() const;
+  StringAttr getLinkageName() const;
+  DIFileAttr getFile() const;
+  unsigned getLine() const;
+  unsigned getScopeLine() const;
+  DISubprogramFlags getSubprogramFlags() const;
+  DISubroutineTypeAttr getType() const;
+};
+namespace detail {
+struct DISubrangeAttrStorage;
+} // namespace detail
+class DISubrangeAttr : public ::mlir::Attribute::AttrBase<DISubrangeAttr, DINodeAttr, detail::DISubrangeAttrStorage> {
+public:
+  using Base::Base;
+  static DISubrangeAttr get(::mlir::MLIRContext *context, IntegerAttr count, IntegerAttr lowerBound, IntegerAttr upperBound, IntegerAttr stride);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_subrange"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  IntegerAttr getCount() const;
+  IntegerAttr getLowerBound() const;
+  IntegerAttr getUpperBound() const;
+  IntegerAttr getStride() const;
+};
+namespace detail {
+struct DISubroutineTypeAttrStorage;
+} // namespace detail
+class DISubroutineTypeAttr : public ::mlir::Attribute::AttrBase<DISubroutineTypeAttr, DITypeAttr, detail::DISubroutineTypeAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static DISubroutineTypeAttr get(::mlir::MLIRContext *context, unsigned callingConvention, DITypeAttr resultType, ::llvm::ArrayRef<DITypeAttr> argumentTypes);
+  static DISubroutineTypeAttr get(::mlir::MLIRContext *context, DITypeAttr resultType, ArrayRef<DITypeAttr> argumentTypes);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"di_subroutine_type"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  unsigned getCallingConvention() const;
+  DITypeAttr getResultType() const;
+  ::llvm::ArrayRef<DITypeAttr> getArgumentTypes() const;
+};
+namespace detail {
+struct FastmathFlagsAttrStorage;
+} // namespace detail
+class FastmathFlagsAttr : public ::mlir::Attribute::AttrBase<FastmathFlagsAttr, ::mlir::Attribute, detail::FastmathFlagsAttrStorage> {
+public:
+  using Base::Base;
+  static FastmathFlagsAttr get(::mlir::MLIRContext *context, ::mlir::LLVM::FastmathFlags value);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"fastmath"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  ::mlir::LLVM::FastmathFlags getValue() const;
+};
+namespace detail {
+struct LinkageAttrStorage;
+} // namespace detail
+class LinkageAttr : public ::mlir::Attribute::AttrBase<LinkageAttr, ::mlir::Attribute, detail::LinkageAttrStorage> {
+public:
+  using Base::Base;
+  static LinkageAttr get(::mlir::MLIRContext *context, linkage::Linkage linkage);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"linkage"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  linkage::Linkage getLinkage() const;
+};
+namespace detail {
+struct LoopOptionsAttrStorage;
+} // namespace detail
+class LoopOptionsAttr : public ::mlir::Attribute::AttrBase<LoopOptionsAttr, ::mlir::Attribute, detail::LoopOptionsAttrStorage> {
+public:
+  using Base::Base;
+  using OptionValuePair = std::pair<LoopOptionCase, int64_t>;
+  using OptionsArray = ArrayRef<std::pair<LoopOptionCase, int64_t>>;
+  Optional<bool> disableUnroll();
+  Optional<bool> disableLICM();
+  Optional<int64_t> interleaveCount();
+  static LoopOptionsAttr get(::mlir::MLIRContext *context, ArrayRef<std::pair<LoopOptionCase, int64_t>> sortedOptions);
+  static LoopOptionsAttr get(::mlir::MLIRContext *context, LoopOptionsAttrBuilder &optionBuilders);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"loopopts"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  ::llvm::ArrayRef<std::pair<LoopOptionCase, int64_t>> getOptions() const;
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::CConvAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DIBasicTypeAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DICompileUnitAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DICompositeTypeAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DIDerivedTypeAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DIFileAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DILexicalBlockAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DILexicalBlockFileAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DILocalVariableAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DISubprogramAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DISubrangeAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::DISubroutineTypeAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::FastmathFlagsAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LinkageAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LoopOptionsAttr)
+
+#endif  // GET_ATTRDEF_CLASSES
+

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOpsDialect.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOpsDialect.h.inc
@@ -1,0 +1,111 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Dialect Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+namespace LLVM {
+
+class LLVMDialect : public ::mlir::Dialect {
+  explicit LLVMDialect(::mlir::MLIRContext *context);
+
+  void initialize();
+  friend class ::mlir::MLIRContext;
+public:
+  ~LLVMDialect() override;
+  static constexpr ::llvm::StringLiteral getDialectNamespace() {
+    return ::llvm::StringLiteral("llvm");
+  }
+
+  /// Parse an attribute registered to this dialect.
+  ::mlir::Attribute parseAttribute(::mlir::DialectAsmParser &parser,
+                                   ::mlir::Type type) const override;
+
+  /// Print an attribute registered to this dialect.
+  void printAttribute(::mlir::Attribute attr,
+                      ::mlir::DialectAsmPrinter &os) const override;
+
+    /// Provides a hook for verifying dialect attributes attached to the given
+    /// op.
+    ::mlir::LogicalResult verifyOperationAttribute(
+        ::mlir::Operation *op, ::mlir::NamedAttribute attribute) override;
+
+    /// Provides a hook for verifying dialect attributes attached to the given
+    /// op's region argument.
+    ::mlir::LogicalResult verifyRegionArgAttribute(
+        ::mlir::Operation *op, unsigned regionIndex, unsigned argIndex,
+        ::mlir::NamedAttribute attribute) override;
+
+    /// Provides a hook for verifying dialect attributes attached to the given
+    /// op's region result.
+    ::mlir::LogicalResult verifyRegionResultAttribute(
+        ::mlir::Operation *op, unsigned regionIndex, unsigned resultIndex,
+        ::mlir::NamedAttribute attribute) override;
+
+    /// Name of the data layout attributes.
+    static StringRef getDataLayoutAttrName() { return "llvm.data_layout"; }
+    static StringRef getAlignAttrName() { return "llvm.align"; }
+    static StringRef getNoAliasAttrName() { return "llvm.noalias"; }
+    static StringRef getReadonlyAttrName() { return "llvm.readonly"; }
+    static StringRef getNoAliasScopesAttrName() { return "noalias_scopes"; }
+    static StringRef getAliasScopesAttrName() { return "alias_scopes"; }
+    static StringRef getLoopAttrName() { return "llvm.loop"; }
+    static StringRef getParallelAccessAttrName() { return "parallel_access"; }
+    static StringRef getLoopOptionsAttrName() { return "options"; }
+    static StringRef getAccessGroupsAttrName() { return "access_groups"; }
+    static StringRef getStructAttrsAttrName() { return "llvm.struct_attrs"; }
+    static StringRef getByValAttrName() { return "llvm.byval"; }
+    static StringRef getByRefAttrName() { return "llvm.byref"; }
+    static StringRef getStructRetAttrName() { return "llvm.sret"; }
+    static StringRef getInAllocaAttrName() { return "llvm.inalloca"; }
+    static StringRef getNoUndefAttrName() { return "llvm.noundef"; }
+    static StringRef getSExtAttrName() { return "llvm.signext"; }
+    static StringRef getZExtAttrName() { return "llvm.zeroext"; }
+
+    /// Verifies if the attribute is a well-formed value for "llvm.struct_attrs"
+    static LogicalResult verifyStructAttr(
+        Operation *op, Attribute attr, Type annotatedType);
+
+    /// Verifies if the given string is a well-formed data layout descriptor.
+    /// Uses `reportError` to report errors.
+    static LogicalResult verifyDataLayoutString(
+        StringRef descr, llvm::function_ref<void (const Twine &)> reportError);
+
+    /// Name of the target triple attribute.
+    static StringRef getTargetTripleAttrName() { return "llvm.target_triple"; }
+
+    /// Name of the C wrapper emission attribute.
+    static StringRef getEmitCWrapperAttrName() {
+      return "llvm.emit_c_interface";
+    }
+
+    /// Returns `true` if the given type is compatible with the LLVM dialect.
+    static bool isCompatibleType(Type);
+
+    /// Name of the attribute mapped to LLVM's 'readnone' function attribute.
+    /// It is allowed on any FunctionOpInterface operations.
+    static StringRef getReadnoneAttrName() {
+      return "llvm.readnone";
+    }
+
+    Type parseType(DialectAsmParser &p) const override;
+    void printType(Type, DialectAsmPrinter &p) const override;
+
+  private:
+    /// Register all types.
+    void registerTypes();
+
+    /// A cache storing compatible LLVM types that have been verified. This
+    /// can save us lots of verification time if there are many occurrences
+    /// of some deeply-nested aggregate types in the program.
+    ThreadLocalCache<DenseSet<Type>> compatibleTypes;
+
+    /// Register the attributes of this dialect.
+    void registerAttributes();
+  };
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LLVMDialect)

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOpsEnums.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOpsEnums.h.inc
@@ -1,0 +1,1414 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Enum Utility Declarations                                                  *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+namespace LLVM {
+// ATT (0) or Intel (1) asm dialect
+enum class AsmDialect : uint64_t {
+  AD_ATT = 0,
+  AD_Intel = 1,
+};
+
+::std::optional<AsmDialect> symbolizeAsmDialect(uint64_t);
+::llvm::StringRef stringifyAsmDialect(AsmDialect);
+::std::optional<AsmDialect> symbolizeAsmDialect(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForAsmDialect() {
+  return 1;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(AsmDialect enumValue) {
+  return stringifyAsmDialect(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<AsmDialect> symbolizeEnum<AsmDialect>(::llvm::StringRef str) {
+  return symbolizeAsmDialect(str);
+}
+
+class AsmDialectAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = AsmDialect;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static AsmDialectAttr get(::mlir::MLIRContext *context, AsmDialect val);
+  AsmDialect getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::AsmDialect, ::mlir::LLVM::AsmDialect> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::AsmDialect> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for ATT (0) or Intel (1) asm dialect");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::AsmDialect> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::AsmDialect>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid ATT (0) or Intel (1) asm dialect specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::AsmDialect value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::AsmDialect> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::AsmDialect getEmptyKey() {
+    return static_cast<::mlir::LLVM::AsmDialect>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::AsmDialect getTombstoneKey() {
+    return static_cast<::mlir::LLVM::AsmDialect>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::AsmDialect &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::AsmDialect &lhs, const ::mlir::LLVM::AsmDialect &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// llvm.atomicrmw binary operations
+enum class AtomicBinOp : uint64_t {
+  xchg = 0,
+  add = 1,
+  sub = 2,
+  _and = 3,
+  nand = 4,
+  _or = 5,
+  _xor = 6,
+  max = 7,
+  min = 8,
+  umax = 9,
+  umin = 10,
+  fadd = 11,
+  fsub = 12,
+};
+
+::std::optional<AtomicBinOp> symbolizeAtomicBinOp(uint64_t);
+::llvm::StringRef stringifyAtomicBinOp(AtomicBinOp);
+::std::optional<AtomicBinOp> symbolizeAtomicBinOp(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForAtomicBinOp() {
+  return 12;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(AtomicBinOp enumValue) {
+  return stringifyAtomicBinOp(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<AtomicBinOp> symbolizeEnum<AtomicBinOp>(::llvm::StringRef str) {
+  return symbolizeAtomicBinOp(str);
+}
+
+class AtomicBinOpAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = AtomicBinOp;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static AtomicBinOpAttr get(::mlir::MLIRContext *context, AtomicBinOp val);
+  AtomicBinOp getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::AtomicBinOp, ::mlir::LLVM::AtomicBinOp> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::AtomicBinOp> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for llvm.atomicrmw binary operations");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::AtomicBinOp> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::AtomicBinOp>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid llvm.atomicrmw binary operations specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::AtomicBinOp value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::AtomicBinOp> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::AtomicBinOp getEmptyKey() {
+    return static_cast<::mlir::LLVM::AtomicBinOp>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::AtomicBinOp getTombstoneKey() {
+    return static_cast<::mlir::LLVM::AtomicBinOp>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::AtomicBinOp &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::AtomicBinOp &lhs, const ::mlir::LLVM::AtomicBinOp &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// Atomic ordering for LLVM's memory model
+enum class AtomicOrdering : uint64_t {
+  not_atomic = 0,
+  unordered = 1,
+  monotonic = 2,
+  acquire = 4,
+  release = 5,
+  acq_rel = 6,
+  seq_cst = 7,
+};
+
+::std::optional<AtomicOrdering> symbolizeAtomicOrdering(uint64_t);
+::llvm::StringRef stringifyAtomicOrdering(AtomicOrdering);
+::std::optional<AtomicOrdering> symbolizeAtomicOrdering(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForAtomicOrdering() {
+  return 7;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(AtomicOrdering enumValue) {
+  return stringifyAtomicOrdering(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<AtomicOrdering> symbolizeEnum<AtomicOrdering>(::llvm::StringRef str) {
+  return symbolizeAtomicOrdering(str);
+}
+
+class AtomicOrderingAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = AtomicOrdering;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static AtomicOrderingAttr get(::mlir::MLIRContext *context, AtomicOrdering val);
+  AtomicOrdering getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::AtomicOrdering, ::mlir::LLVM::AtomicOrdering> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::AtomicOrdering> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for Atomic ordering for LLVM's memory model");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::AtomicOrdering> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::AtomicOrdering>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid Atomic ordering for LLVM's memory model specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::AtomicOrdering value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::AtomicOrdering> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::AtomicOrdering getEmptyKey() {
+    return static_cast<::mlir::LLVM::AtomicOrdering>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::AtomicOrdering getTombstoneKey() {
+    return static_cast<::mlir::LLVM::AtomicOrdering>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::AtomicOrdering &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::AtomicOrdering &lhs, const ::mlir::LLVM::AtomicOrdering &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+namespace cconv {
+// Calling Conventions
+enum class CConv : uint64_t {
+  C = 0,
+  Fast = 8,
+  Cold = 9,
+  GHC = 10,
+  HiPE = 11,
+  WebKit_JS = 12,
+  AnyReg = 13,
+  PreserveMost = 14,
+  PreserveAll = 15,
+  Swift = 16,
+  CXX_FAST_TLS = 17,
+  Tail = 18,
+  CFGuard_Check = 19,
+  SwiftTail = 20,
+  X86_StdCall = 64,
+  X86_FastCall = 65,
+  ARM_APCS = 66,
+  ARM_AAPCS = 67,
+  ARM_AAPCS_VFP = 68,
+  MSP430_INTR = 69,
+  X86_ThisCall = 70,
+  PTX_Kernel = 71,
+  PTX_Device = 72,
+  SPIR_FUNC = 75,
+  SPIR_KERNEL = 76,
+  Intel_OCL_BI = 77,
+  X86_64_SysV = 78,
+  Win64 = 79,
+  X86_VectorCall = 80,
+  HHVM = 81,
+  HHVM_C = 82,
+  X86_INTR = 83,
+  AVR_INTR = 84,
+  AVR_BUILTIN = 86,
+  AMDGPU_VS = 87,
+  AMDGPU_GS = 88,
+  AMDGPU_CS = 90,
+  AMDGPU_KERNEL = 91,
+  X86_RegCall = 92,
+  AMDGPU_HS = 93,
+  MSP430_BUILTIN = 94,
+  AMDGPU_LS = 95,
+  AMDGPU_ES = 96,
+  AArch64_VectorCall = 97,
+  AArch64_SVE_VectorCall = 98,
+  WASM_EmscriptenInvoke = 99,
+  AMDGPU_Gfx = 100,
+  M68k_INTR = 101,
+};
+
+::std::optional<CConv> symbolizeCConv(uint64_t);
+::llvm::StringRef stringifyCConv(CConv);
+::std::optional<CConv> symbolizeCConv(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForCConv() {
+  return 101;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(CConv enumValue) {
+  return stringifyCConv(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<CConv> symbolizeEnum<CConv>(::llvm::StringRef str) {
+  return symbolizeCConv(str);
+}
+
+class CConvAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = CConv;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static CConvAttr get(::mlir::MLIRContext *context, CConv val);
+  CConv getValue() const;
+};
+} // namespace cconv
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::cconv::CConv, ::mlir::LLVM::cconv::CConv> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::cconv::CConv> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for Calling Conventions");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::cconv::CConv> attr = ::mlir::LLVM::cconv::symbolizeEnum<::mlir::LLVM::cconv::CConv>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid Calling Conventions specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::cconv::CConv value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::cconv::CConv> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::cconv::CConv getEmptyKey() {
+    return static_cast<::mlir::LLVM::cconv::CConv>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::cconv::CConv getTombstoneKey() {
+    return static_cast<::mlir::LLVM::cconv::CConv>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::cconv::CConv &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::cconv::CConv &lhs, const ::mlir::LLVM::cconv::CConv &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// LLVM DI flags
+enum class DIFlags : uint32_t {
+  Zero = 0,
+  Bit0 = 1,
+  Bit1 = 2,
+  Private = 1,
+  Protected = 2,
+  Public = 3,
+  FwdDecl = 4,
+  AppleBlock = 8,
+  ReservedBit4 = 16,
+  Virtual = 32,
+  Artificial = 64,
+  Explicit = 128,
+  Prototyped = 256,
+  ObjcClassComplete = 512,
+  ObjectPointer = 1024,
+  Vector = 2048,
+  StaticMember = 4096,
+  LValueReference = 8192,
+  RValueReference = 16384,
+  ExportSymbols = 32768,
+  SingleInheritance = 65536,
+  MultipleInheritance = 65536,
+  VirtualInheritance = 65536,
+  IntroducedVirtual = 262144,
+  BitField = 524288,
+  NoReturn = 1048576,
+  TypePassByValue = 4194304,
+  TypePassByReference = 8388608,
+  EnumClass = 16777216,
+  Thunk = 33554432,
+  NonTrivial = 67108864,
+  BigEndian = 134217728,
+  LittleEndian = 268435456,
+  AllCallsDescribed = 536870912,
+};
+
+::std::optional<DIFlags> symbolizeDIFlags(uint32_t);
+std::string stringifyDIFlags(DIFlags);
+::std::optional<DIFlags> symbolizeDIFlags(::llvm::StringRef);
+
+inline constexpr DIFlags operator|(DIFlags a, DIFlags b) {
+  return static_cast<DIFlags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+inline constexpr DIFlags operator&(DIFlags a, DIFlags b) {
+  return static_cast<DIFlags>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+}
+inline constexpr DIFlags operator^(DIFlags a, DIFlags b) {
+  return static_cast<DIFlags>(static_cast<uint32_t>(a) ^ static_cast<uint32_t>(b));
+}
+inline constexpr DIFlags operator~(DIFlags bits) {
+  // Ensure only bits that can be present in the enum are set
+  return static_cast<DIFlags>(~static_cast<uint32_t>(bits) & static_cast<uint32_t>(1071513599u));
+}
+inline constexpr bool bitEnumContainsAll(DIFlags bits, DIFlags bit) {
+  return (bits & bit) == bit;
+}
+inline constexpr bool bitEnumContainsAny(DIFlags bits, DIFlags bit) {
+  return (static_cast<uint32_t>(bits) & static_cast<uint32_t>(bit)) != 0;
+}
+inline constexpr DIFlags bitEnumClear(DIFlags bits, DIFlags bit) {
+  return bits & ~bit;
+}
+inline constexpr DIFlags bitEnumSet(DIFlags bits, DIFlags bit, /*optional*/bool value=true) {
+  return value ? (bits | bit) : bitEnumClear(bits, bit);
+}
+  
+inline std::string stringifyEnum(DIFlags enumValue) {
+  return stringifyDIFlags(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<DIFlags> symbolizeEnum<DIFlags>(::llvm::StringRef str) {
+  return symbolizeDIFlags(str);
+}
+
+class DIFlagsAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = DIFlags;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static DIFlagsAttr get(::mlir::MLIRContext *context, DIFlags val);
+  DIFlags getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::DIFlags, ::mlir::LLVM::DIFlags> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::DIFlags> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for LLVM DI flags");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::DIFlags> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::DIFlags>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid LLVM DI flags specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::DIFlags value) {
+  auto valueStr = stringifyEnum(value);
+  switch (value) {
+  case ::mlir::LLVM::DIFlags::Public:
+    return p << valueStr;
+  default:
+    break;
+  }
+  auto underlyingValue = static_cast<std::make_unsigned_t<::mlir::LLVM::DIFlags>>(value);
+  if (underlyingValue && !llvm::has_single_bit(underlyingValue))
+    return p << '"' << valueStr << '"';
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::DIFlags> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::LLVM::DIFlags getEmptyKey() {
+    return static_cast<::mlir::LLVM::DIFlags>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::DIFlags getTombstoneKey() {
+    return static_cast<::mlir::LLVM::DIFlags>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::DIFlags &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::DIFlags &lhs, const ::mlir::LLVM::DIFlags &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// LLVM DISubprogram flags
+enum class DISubprogramFlags : uint32_t {
+  Virtual = 1,
+  PureVirtual = 2,
+  LocalToUnit = 4,
+  Definition = 8,
+  Optimized = 16,
+  Pure = 32,
+  Elemental = 64,
+  Recursive = 128,
+  MainSubprogram = 256,
+  Deleted = 512,
+  ObjCDirect = 2048,
+};
+
+::std::optional<DISubprogramFlags> symbolizeDISubprogramFlags(uint32_t);
+std::string stringifyDISubprogramFlags(DISubprogramFlags);
+::std::optional<DISubprogramFlags> symbolizeDISubprogramFlags(::llvm::StringRef);
+
+inline constexpr DISubprogramFlags operator|(DISubprogramFlags a, DISubprogramFlags b) {
+  return static_cast<DISubprogramFlags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+inline constexpr DISubprogramFlags operator&(DISubprogramFlags a, DISubprogramFlags b) {
+  return static_cast<DISubprogramFlags>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+}
+inline constexpr DISubprogramFlags operator^(DISubprogramFlags a, DISubprogramFlags b) {
+  return static_cast<DISubprogramFlags>(static_cast<uint32_t>(a) ^ static_cast<uint32_t>(b));
+}
+inline constexpr DISubprogramFlags operator~(DISubprogramFlags bits) {
+  // Ensure only bits that can be present in the enum are set
+  return static_cast<DISubprogramFlags>(~static_cast<uint32_t>(bits) & static_cast<uint32_t>(3071u));
+}
+inline constexpr bool bitEnumContainsAll(DISubprogramFlags bits, DISubprogramFlags bit) {
+  return (bits & bit) == bit;
+}
+inline constexpr bool bitEnumContainsAny(DISubprogramFlags bits, DISubprogramFlags bit) {
+  return (static_cast<uint32_t>(bits) & static_cast<uint32_t>(bit)) != 0;
+}
+inline constexpr DISubprogramFlags bitEnumClear(DISubprogramFlags bits, DISubprogramFlags bit) {
+  return bits & ~bit;
+}
+inline constexpr DISubprogramFlags bitEnumSet(DISubprogramFlags bits, DISubprogramFlags bit, /*optional*/bool value=true) {
+  return value ? (bits | bit) : bitEnumClear(bits, bit);
+}
+  
+inline std::string stringifyEnum(DISubprogramFlags enumValue) {
+  return stringifyDISubprogramFlags(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<DISubprogramFlags> symbolizeEnum<DISubprogramFlags>(::llvm::StringRef str) {
+  return symbolizeDISubprogramFlags(str);
+}
+
+class DISubprogramFlagsAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = DISubprogramFlags;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static DISubprogramFlagsAttr get(::mlir::MLIRContext *context, DISubprogramFlags val);
+  DISubprogramFlags getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::DISubprogramFlags, ::mlir::LLVM::DISubprogramFlags> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::DISubprogramFlags> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for LLVM DISubprogram flags");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::DISubprogramFlags> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::DISubprogramFlags>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid LLVM DISubprogram flags specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::DISubprogramFlags value) {
+  auto valueStr = stringifyEnum(value);
+  auto underlyingValue = static_cast<std::make_unsigned_t<::mlir::LLVM::DISubprogramFlags>>(value);
+  if (underlyingValue && !llvm::has_single_bit(underlyingValue))
+    return p << '"' << valueStr << '"';
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::DISubprogramFlags> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::LLVM::DISubprogramFlags getEmptyKey() {
+    return static_cast<::mlir::LLVM::DISubprogramFlags>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::DISubprogramFlags getTombstoneKey() {
+    return static_cast<::mlir::LLVM::DISubprogramFlags>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::DISubprogramFlags &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::DISubprogramFlags &lhs, const ::mlir::LLVM::DISubprogramFlags &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// llvm.fcmp comparison predicate
+enum class FCmpPredicate : uint64_t {
+  _false = 0,
+  oeq = 1,
+  ogt = 2,
+  oge = 3,
+  olt = 4,
+  ole = 5,
+  one = 6,
+  ord = 7,
+  ueq = 8,
+  ugt = 9,
+  uge = 10,
+  ult = 11,
+  ule = 12,
+  une = 13,
+  uno = 14,
+  _true = 15,
+};
+
+::std::optional<FCmpPredicate> symbolizeFCmpPredicate(uint64_t);
+::llvm::StringRef stringifyFCmpPredicate(FCmpPredicate);
+::std::optional<FCmpPredicate> symbolizeFCmpPredicate(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForFCmpPredicate() {
+  return 15;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(FCmpPredicate enumValue) {
+  return stringifyFCmpPredicate(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<FCmpPredicate> symbolizeEnum<FCmpPredicate>(::llvm::StringRef str) {
+  return symbolizeFCmpPredicate(str);
+}
+
+class FCmpPredicateAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = FCmpPredicate;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static FCmpPredicateAttr get(::mlir::MLIRContext *context, FCmpPredicate val);
+  FCmpPredicate getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::FCmpPredicate, ::mlir::LLVM::FCmpPredicate> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::FCmpPredicate> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for llvm.fcmp comparison predicate");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::FCmpPredicate> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::FCmpPredicate>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid llvm.fcmp comparison predicate specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::FCmpPredicate value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::FCmpPredicate> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::FCmpPredicate getEmptyKey() {
+    return static_cast<::mlir::LLVM::FCmpPredicate>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::FCmpPredicate getTombstoneKey() {
+    return static_cast<::mlir::LLVM::FCmpPredicate>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::FCmpPredicate &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::FCmpPredicate &lhs, const ::mlir::LLVM::FCmpPredicate &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// LLVM fastmath flags
+enum class FastmathFlags : uint32_t {
+  none = 0,
+  nnan = 1,
+  ninf = 2,
+  nsz = 4,
+  arcp = 8,
+  contract = 16,
+  afn = 32,
+  reassoc = 64,
+  fast = 127,
+};
+
+::std::optional<FastmathFlags> symbolizeFastmathFlags(uint32_t);
+std::string stringifyFastmathFlags(FastmathFlags);
+::std::optional<FastmathFlags> symbolizeFastmathFlags(::llvm::StringRef);
+
+inline constexpr FastmathFlags operator|(FastmathFlags a, FastmathFlags b) {
+  return static_cast<FastmathFlags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+inline constexpr FastmathFlags operator&(FastmathFlags a, FastmathFlags b) {
+  return static_cast<FastmathFlags>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+}
+inline constexpr FastmathFlags operator^(FastmathFlags a, FastmathFlags b) {
+  return static_cast<FastmathFlags>(static_cast<uint32_t>(a) ^ static_cast<uint32_t>(b));
+}
+inline constexpr FastmathFlags operator~(FastmathFlags bits) {
+  // Ensure only bits that can be present in the enum are set
+  return static_cast<FastmathFlags>(~static_cast<uint32_t>(bits) & static_cast<uint32_t>(127u));
+}
+inline constexpr bool bitEnumContainsAll(FastmathFlags bits, FastmathFlags bit) {
+  return (bits & bit) == bit;
+}
+inline constexpr bool bitEnumContainsAny(FastmathFlags bits, FastmathFlags bit) {
+  return (static_cast<uint32_t>(bits) & static_cast<uint32_t>(bit)) != 0;
+}
+inline constexpr FastmathFlags bitEnumClear(FastmathFlags bits, FastmathFlags bit) {
+  return bits & ~bit;
+}
+inline constexpr FastmathFlags bitEnumSet(FastmathFlags bits, FastmathFlags bit, /*optional*/bool value=true) {
+  return value ? (bits | bit) : bitEnumClear(bits, bit);
+}
+  
+inline std::string stringifyEnum(FastmathFlags enumValue) {
+  return stringifyFastmathFlags(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<FastmathFlags> symbolizeEnum<FastmathFlags>(::llvm::StringRef str) {
+  return symbolizeFastmathFlags(str);
+}
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::FastmathFlags, ::mlir::LLVM::FastmathFlags> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::FastmathFlags> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for LLVM fastmath flags");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::FastmathFlags> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::FastmathFlags>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid LLVM fastmath flags specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::FastmathFlags value) {
+  auto valueStr = stringifyEnum(value);
+  switch (value) {
+  case ::mlir::LLVM::FastmathFlags::fast:
+    return p << valueStr;
+  default:
+    break;
+  }
+  auto underlyingValue = static_cast<std::make_unsigned_t<::mlir::LLVM::FastmathFlags>>(value);
+  if (underlyingValue && !llvm::has_single_bit(underlyingValue))
+    return p << '"' << valueStr << '"';
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::FastmathFlags> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::LLVM::FastmathFlags getEmptyKey() {
+    return static_cast<::mlir::LLVM::FastmathFlags>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::FastmathFlags getTombstoneKey() {
+    return static_cast<::mlir::LLVM::FastmathFlags>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::FastmathFlags &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::FastmathFlags &lhs, const ::mlir::LLVM::FastmathFlags &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// llvm.icmp comparison predicate
+enum class ICmpPredicate : uint64_t {
+  eq = 0,
+  ne = 1,
+  slt = 2,
+  sle = 3,
+  sgt = 4,
+  sge = 5,
+  ult = 6,
+  ule = 7,
+  ugt = 8,
+  uge = 9,
+};
+
+::std::optional<ICmpPredicate> symbolizeICmpPredicate(uint64_t);
+::llvm::StringRef stringifyICmpPredicate(ICmpPredicate);
+::std::optional<ICmpPredicate> symbolizeICmpPredicate(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForICmpPredicate() {
+  return 9;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(ICmpPredicate enumValue) {
+  return stringifyICmpPredicate(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<ICmpPredicate> symbolizeEnum<ICmpPredicate>(::llvm::StringRef str) {
+  return symbolizeICmpPredicate(str);
+}
+
+class ICmpPredicateAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = ICmpPredicate;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static ICmpPredicateAttr get(::mlir::MLIRContext *context, ICmpPredicate val);
+  ICmpPredicate getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::ICmpPredicate, ::mlir::LLVM::ICmpPredicate> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::ICmpPredicate> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for llvm.icmp comparison predicate");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::ICmpPredicate> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::ICmpPredicate>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid llvm.icmp comparison predicate specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::ICmpPredicate value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::ICmpPredicate> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::ICmpPredicate getEmptyKey() {
+    return static_cast<::mlir::LLVM::ICmpPredicate>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::ICmpPredicate getTombstoneKey() {
+    return static_cast<::mlir::LLVM::ICmpPredicate>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::ICmpPredicate &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::ICmpPredicate &lhs, const ::mlir::LLVM::ICmpPredicate &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// LLVM debug emission kind
+enum class DIEmissionKind : uint64_t {
+  None = 0,
+  Full = 1,
+  LineTablesOnly = 2,
+  DebugDirectivesOnly = 3,
+};
+
+::std::optional<DIEmissionKind> symbolizeDIEmissionKind(uint64_t);
+::llvm::StringRef stringifyDIEmissionKind(DIEmissionKind);
+::std::optional<DIEmissionKind> symbolizeDIEmissionKind(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForDIEmissionKind() {
+  return 3;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(DIEmissionKind enumValue) {
+  return stringifyDIEmissionKind(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<DIEmissionKind> symbolizeEnum<DIEmissionKind>(::llvm::StringRef str) {
+  return symbolizeDIEmissionKind(str);
+}
+
+class DIEmissionKindAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = DIEmissionKind;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static DIEmissionKindAttr get(::mlir::MLIRContext *context, DIEmissionKind val);
+  DIEmissionKind getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::DIEmissionKind, ::mlir::LLVM::DIEmissionKind> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::DIEmissionKind> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for LLVM debug emission kind");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::DIEmissionKind> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::DIEmissionKind>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid LLVM debug emission kind specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::DIEmissionKind value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::DIEmissionKind> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::DIEmissionKind getEmptyKey() {
+    return static_cast<::mlir::LLVM::DIEmissionKind>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::DIEmissionKind getTombstoneKey() {
+    return static_cast<::mlir::LLVM::DIEmissionKind>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::DIEmissionKind &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::DIEmissionKind &lhs, const ::mlir::LLVM::DIEmissionKind &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+namespace linkage {
+// LLVM linkage types
+enum class Linkage : uint64_t {
+  Private = 0,
+  Internal = 1,
+  AvailableExternally = 2,
+  Linkonce = 3,
+  Weak = 4,
+  Common = 5,
+  Appending = 6,
+  ExternWeak = 7,
+  LinkonceODR = 8,
+  WeakODR = 9,
+  External = 10,
+};
+
+::std::optional<Linkage> symbolizeLinkage(uint64_t);
+::llvm::StringRef stringifyLinkage(Linkage);
+::std::optional<Linkage> symbolizeLinkage(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForLinkage() {
+  return 10;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(Linkage enumValue) {
+  return stringifyLinkage(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<Linkage> symbolizeEnum<Linkage>(::llvm::StringRef str) {
+  return symbolizeLinkage(str);
+}
+
+class LinkageAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = Linkage;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static LinkageAttr get(::mlir::MLIRContext *context, Linkage val);
+  Linkage getValue() const;
+};
+} // namespace linkage
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::linkage::Linkage, ::mlir::LLVM::linkage::Linkage> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::linkage::Linkage> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for LLVM linkage types");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::linkage::Linkage> attr = ::mlir::LLVM::linkage::symbolizeEnum<::mlir::LLVM::linkage::Linkage>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid LLVM linkage types specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::linkage::Linkage value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::linkage::Linkage> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::linkage::Linkage getEmptyKey() {
+    return static_cast<::mlir::LLVM::linkage::Linkage>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::linkage::Linkage getTombstoneKey() {
+    return static_cast<::mlir::LLVM::linkage::Linkage>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::linkage::Linkage &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::linkage::Linkage &lhs, const ::mlir::LLVM::linkage::Linkage &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// LLVM loop option
+enum class LoopOptionCase : uint32_t {
+  disable_unroll = 1,
+  disable_licm = 2,
+  interleave_count = 3,
+  disable_pipeline = 4,
+  pipeline_initiation_interval = 5,
+};
+
+::std::optional<LoopOptionCase> symbolizeLoopOptionCase(uint32_t);
+::llvm::StringRef stringifyLoopOptionCase(LoopOptionCase);
+::std::optional<LoopOptionCase> symbolizeLoopOptionCase(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForLoopOptionCase() {
+  return 5;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(LoopOptionCase enumValue) {
+  return stringifyLoopOptionCase(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<LoopOptionCase> symbolizeEnum<LoopOptionCase>(::llvm::StringRef str) {
+  return symbolizeLoopOptionCase(str);
+}
+
+class LoopOptionCaseAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = LoopOptionCase;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static LoopOptionCaseAttr get(::mlir::MLIRContext *context, LoopOptionCase val);
+  LoopOptionCase getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::LoopOptionCase, ::mlir::LLVM::LoopOptionCase> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::LoopOptionCase> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for LLVM loop option");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::LoopOptionCase> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::LoopOptionCase>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid LLVM loop option specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::LoopOptionCase value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::LoopOptionCase> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::LLVM::LoopOptionCase getEmptyKey() {
+    return static_cast<::mlir::LLVM::LoopOptionCase>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::LoopOptionCase getTombstoneKey() {
+    return static_cast<::mlir::LLVM::LoopOptionCase>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::LoopOptionCase &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::LoopOptionCase &lhs, const ::mlir::LLVM::LoopOptionCase &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace LLVM {
+// LLVM GlobalValue UnnamedAddr
+enum class UnnamedAddr : uint64_t {
+  None = 0,
+  Local = 1,
+  Global = 2,
+};
+
+::std::optional<UnnamedAddr> symbolizeUnnamedAddr(uint64_t);
+::llvm::StringRef stringifyUnnamedAddr(UnnamedAddr);
+::std::optional<UnnamedAddr> symbolizeUnnamedAddr(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForUnnamedAddr() {
+  return 2;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(UnnamedAddr enumValue) {
+  return stringifyUnnamedAddr(enumValue);
+}
+
+template <typename EnumType>
+::std::optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::std::optional<UnnamedAddr> symbolizeEnum<UnnamedAddr>(::llvm::StringRef str) {
+  return symbolizeUnnamedAddr(str);
+}
+
+class UnnamedAddrAttr : public ::mlir::IntegerAttr {
+public:
+  using ValueType = UnnamedAddr;
+  using ::mlir::IntegerAttr::IntegerAttr;
+  static bool classof(::mlir::Attribute attr);
+  static UnnamedAddrAttr get(::mlir::MLIRContext *context, UnnamedAddr val);
+  UnnamedAddr getValue() const;
+};
+} // namespace LLVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::LLVM::UnnamedAddr, ::mlir::LLVM::UnnamedAddr> {
+  template <typename ParserT>
+  static FailureOr<::mlir::LLVM::UnnamedAddr> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for LLVM GlobalValue UnnamedAddr");
+
+    // Symbolize the keyword.
+    if (::std::optional<::mlir::LLVM::UnnamedAddr> attr = ::mlir::LLVM::symbolizeEnum<::mlir::LLVM::UnnamedAddr>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid LLVM GlobalValue UnnamedAddr specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::LLVM::UnnamedAddr value) {
+  auto valueStr = stringifyEnum(value);
+  switch (value) {
+  case ::mlir::LLVM::UnnamedAddr::Local:
+  case ::mlir::LLVM::UnnamedAddr::Global:
+    break;
+  default:
+    return p << '"' << valueStr << '"';
+  }
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::LLVM::UnnamedAddr> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint64_t>;
+
+  static inline ::mlir::LLVM::UnnamedAddr getEmptyKey() {
+    return static_cast<::mlir::LLVM::UnnamedAddr>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::LLVM::UnnamedAddr getTombstoneKey() {
+    return static_cast<::mlir::LLVM::UnnamedAddr>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::LLVM::UnnamedAddr &val) {
+    return StorageInfo::getHashValue(static_cast<uint64_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::LLVM::UnnamedAddr &lhs, const ::mlir::LLVM::UnnamedAddr &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOpsInterfaces.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOpsInterfaces.h.inc
@@ -1,0 +1,103 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+namespace LLVM {
+class FastmathFlagsInterface;
+namespace detail {
+struct FastmathFlagsInterfaceInterfaceTraits {
+  struct Concept {
+    FastmathFlagsAttr (*getFastmathAttr)(const Concept *impl, ::mlir::Operation *);
+    StringRef (*getFastmathAttrName)();
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::LLVM::FastmathFlagsInterface;
+    Model() : Concept{getFastmathAttr, getFastmathAttrName} {}
+
+    static inline FastmathFlagsAttr getFastmathAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline StringRef getFastmathAttrName();
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::LLVM::FastmathFlagsInterface;
+    FallbackModel() : Concept{getFastmathAttr, getFastmathAttrName} {}
+
+    static inline FastmathFlagsAttr getFastmathAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline StringRef getFastmathAttrName();
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+    FastmathFlagsAttr getFastmathAttr(::mlir::Operation *tablegen_opaque_val) const;
+    static StringRef getFastmathAttrName();
+  };
+};template <typename ConcreteOp>
+struct FastmathFlagsInterfaceTrait;
+
+} // namespace detail
+class FastmathFlagsInterface : public ::mlir::OpInterface<FastmathFlagsInterface, detail::FastmathFlagsInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<FastmathFlagsInterface, detail::FastmathFlagsInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::FastmathFlagsInterfaceTrait<ConcreteOp> {};
+  /// Returns a FastmathFlagsAttr attribute for the operation
+  FastmathFlagsAttr getFastmathAttr();
+  /// Returns the name of the FastmathFlagsAttr attribute
+  ///                          for the operation
+  StringRef getFastmathAttrName();
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct FastmathFlagsInterfaceTrait : public ::mlir::OpInterface<FastmathFlagsInterface, detail::FastmathFlagsInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+    /// Returns a FastmathFlagsAttr attribute for the operation
+    FastmathFlagsAttr getFastmathAttr() {
+      ConcreteOp op = cast<ConcreteOp>(this->getOperation());
+        return op.getFastmathFlagsAttr();
+    }
+    /// Returns the name of the FastmathFlagsAttr attribute
+    ///                          for the operation
+    static StringRef getFastmathAttrName() {
+      return "fastmathFlags";
+    }
+  };
+}// namespace detail
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+template<typename ConcreteOp>
+FastmathFlagsAttr detail::FastmathFlagsInterfaceInterfaceTraits::Model<ConcreteOp>::getFastmathAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getFastmathAttr();
+}
+template<typename ConcreteOp>
+StringRef detail::FastmathFlagsInterfaceInterfaceTraits::Model<ConcreteOp>::getFastmathAttrName() {
+  return ConcreteOp::getFastmathAttrName();
+}
+template<typename ConcreteOp>
+FastmathFlagsAttr detail::FastmathFlagsInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getFastmathAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getFastmathAttr(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+StringRef detail::FastmathFlagsInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getFastmathAttrName() {
+  return ConcreteOp::getFastmathAttrName();
+}
+template<typename ConcreteModel, typename ConcreteOp>
+FastmathFlagsAttr detail::FastmathFlagsInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getFastmathAttr(::mlir::Operation *tablegen_opaque_val) const {
+ConcreteOp op = cast<ConcreteOp>(this->getOperation());
+        return op.getFastmathFlagsAttr();
+}
+template<typename ConcreteModel, typename ConcreteOp>
+StringRef detail::FastmathFlagsInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getFastmathAttrName() {
+return "fastmathFlags";
+}
+} // namespace LLVM
+} // namespace mlir

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypeInterfaces.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypeInterfaces.h.inc
@@ -1,0 +1,77 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+namespace LLVM {
+class PointerElementTypeInterface;
+namespace detail {
+struct PointerElementTypeInterfaceInterfaceTraits {
+  struct Concept {
+    unsigned (*getSizeInBytes)(const Concept *impl, ::mlir::Type , const DataLayout &);
+  };
+  template<typename ConcreteType>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::LLVM::PointerElementTypeInterface;
+    Model() : Concept{getSizeInBytes} {}
+
+    static inline unsigned getSizeInBytes(const Concept *impl, ::mlir::Type tablegen_opaque_val, const DataLayout & dataLayout);
+  };
+  template<typename ConcreteType>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::LLVM::PointerElementTypeInterface;
+    FallbackModel() : Concept{getSizeInBytes} {}
+
+    static inline unsigned getSizeInBytes(const Concept *impl, ::mlir::Type tablegen_opaque_val, const DataLayout & dataLayout);
+  };
+  template<typename ConcreteModel, typename ConcreteType>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteType;
+    unsigned getSizeInBytes(::mlir::Type tablegen_opaque_val, const DataLayout &dataLayout) const;
+  };
+};template <typename ConcreteType>
+struct PointerElementTypeInterfaceTrait;
+
+} // namespace detail
+class PointerElementTypeInterface : public ::mlir::TypeInterface<PointerElementTypeInterface, detail::PointerElementTypeInterfaceInterfaceTraits> {
+public:
+  using ::mlir::TypeInterface<PointerElementTypeInterface, detail::PointerElementTypeInterfaceInterfaceTraits>::TypeInterface;
+  template <typename ConcreteType>
+  struct Trait : public detail::PointerElementTypeInterfaceTrait<ConcreteType> {};
+  /// Returns the size of the type in bytes.
+  unsigned getSizeInBytes(const DataLayout & dataLayout) const;
+};
+namespace detail {
+  template <typename ConcreteType>
+  struct PointerElementTypeInterfaceTrait : public ::mlir::TypeInterface<PointerElementTypeInterface, detail::PointerElementTypeInterfaceInterfaceTraits>::Trait<ConcreteType> {
+    /// Returns the size of the type in bytes.
+    unsigned getSizeInBytes(const DataLayout & dataLayout) const {
+      return dataLayout.getTypeSize((*static_cast<const ConcreteType *>(this)));
+    }
+  };
+}// namespace detail
+} // namespace LLVM
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+template<typename ConcreteType>
+unsigned detail::PointerElementTypeInterfaceInterfaceTraits::Model<ConcreteType>::getSizeInBytes(const Concept *impl, ::mlir::Type tablegen_opaque_val, const DataLayout & dataLayout) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).getSizeInBytes(dataLayout);
+}
+template<typename ConcreteType>
+unsigned detail::PointerElementTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::getSizeInBytes(const Concept *impl, ::mlir::Type tablegen_opaque_val, const DataLayout & dataLayout) {
+  return static_cast<const ConcreteType *>(impl)->getSizeInBytes(tablegen_opaque_val, dataLayout);
+}
+template<typename ConcreteModel, typename ConcreteType>
+unsigned detail::PointerElementTypeInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteType>::getSizeInBytes(::mlir::Type tablegen_opaque_val, const DataLayout &dataLayout) const {
+return dataLayout.getTypeSize((tablegen_opaque_val.cast<ConcreteType>()));
+}
+} // namespace LLVM
+} // namespace mlir

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.h.inc
@@ -1,0 +1,184 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* TypeDef Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifdef GET_TYPEDEF_CLASSES
+#undef GET_TYPEDEF_CLASSES
+
+
+namespace mlir {
+class AsmParser;
+class AsmPrinter;
+} // namespace mlir
+namespace mlir {
+namespace LLVM {
+class LLVMArrayType;
+class LLVMFixedVectorType;
+class LLVMFunctionType;
+class LLVMPointerType;
+class LLVMScalableVectorType;
+namespace detail {
+struct LLVMArrayTypeStorage;
+} // namespace detail
+class LLVMArrayType : public ::mlir::Type::TypeBase<LLVMArrayType, ::mlir::Type, detail::LLVMArrayTypeStorage, ::mlir::DataLayoutTypeInterface::Trait, ::mlir::SubElementTypeInterface::Trait> {
+public:
+  using Base::Base;
+  /// Checks if the given type can be used inside an array type.
+  static bool isValidElementType(Type type);
+  using Base::getChecked;
+  static LLVMArrayType get(::mlir::MLIRContext *context, Type elementType, unsigned numElements);
+  static LLVMArrayType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, Type elementType, unsigned numElements);
+  static LLVMArrayType get(Type elementType, unsigned numElements);
+  static LLVMArrayType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned numElements);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned numElements);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"array"};
+  }
+
+  static ::mlir::Type parse(::mlir::AsmParser &odsParser);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  Type getElementType() const;
+  unsigned getNumElements() const;
+  unsigned getTypeSize(const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  unsigned getTypeSizeInBits(const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  unsigned getABIAlignment(const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  unsigned getPreferredAlignment(const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+};
+namespace detail {
+struct LLVMFixedVectorTypeStorage;
+} // namespace detail
+class LLVMFixedVectorType : public ::mlir::Type::TypeBase<LLVMFixedVectorType, ::mlir::Type, detail::LLVMFixedVectorTypeStorage, ::mlir::SubElementTypeInterface::Trait> {
+public:
+  using Base::Base;
+  /// Checks if the given type can be used in a vector type.
+  static bool isValidElementType(Type type);
+  using Base::getChecked;
+  static LLVMFixedVectorType get(::mlir::MLIRContext *context, Type elementType, unsigned numElements);
+  static LLVMFixedVectorType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, Type elementType, unsigned numElements);
+  static LLVMFixedVectorType get(Type elementType, unsigned numElements);
+  static LLVMFixedVectorType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned numElements);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned numElements);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"vec"};
+  }
+
+  static ::mlir::Type parse(::mlir::AsmParser &odsParser);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  Type getElementType() const;
+  unsigned getNumElements() const;
+};
+namespace detail {
+struct LLVMFunctionTypeStorage;
+} // namespace detail
+class LLVMFunctionType : public ::mlir::Type::TypeBase<LLVMFunctionType, ::mlir::Type, detail::LLVMFunctionTypeStorage, ::mlir::SubElementTypeInterface::Trait> {
+public:
+  using Base::Base;
+  /// Checks if the given type can be used an argument in a function type.
+  static bool isValidArgumentType(Type type);
+
+  /// Checks if the given type can be used as a result in a function type.
+  static bool isValidResultType(Type type);
+
+  /// Returns whether the function is variadic.
+  bool isVarArg() const { return getVarArg(); }
+
+  /// Returns a clone of this function type with the given argument
+  /// and result types.
+  LLVMFunctionType clone(TypeRange inputs, TypeRange results) const;
+
+  /// Returns the result type of the function as an ArrayRef, enabling better
+  /// integration with generic MLIR utilities.
+  ArrayRef<Type> getReturnTypes() const;
+
+  /// Returns the number of arguments to the function.
+  unsigned getNumParams() const { return getParams().size(); }
+
+  /// Returns `i`-th argument of the function. Asserts on out-of-bounds.
+  Type getParamType(unsigned i) { return getParams()[i]; }
+  using Base::getChecked;
+  static LLVMFunctionType get(::mlir::MLIRContext *context, Type returnType, ::llvm::ArrayRef<Type> params, bool varArg);
+  static LLVMFunctionType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, Type returnType, ::llvm::ArrayRef<Type> params, bool varArg);
+  static LLVMFunctionType get(Type result, ArrayRef<Type> arguments, bool isVarArg = false);
+  static LLVMFunctionType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type result, ArrayRef<Type> arguments, bool isVarArg = false);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type returnType, ::llvm::ArrayRef<Type> params, bool varArg);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"func"};
+  }
+
+  static ::mlir::Type parse(::mlir::AsmParser &odsParser);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  Type getReturnType() const;
+  ::llvm::ArrayRef<Type> getParams() const;
+  bool getVarArg() const;
+};
+namespace detail {
+struct LLVMPointerTypeStorage;
+} // namespace detail
+class LLVMPointerType : public ::mlir::Type::TypeBase<LLVMPointerType, ::mlir::Type, detail::LLVMPointerTypeStorage, ::mlir::DataLayoutTypeInterface::Trait, ::mlir::SubElementTypeInterface::Trait> {
+public:
+  using Base::Base;
+  /// Returns `true` if this type is the opaque pointer type, i.e., it has no
+  /// pointed-to type.
+  bool isOpaque() const { return !getElementType(); }
+
+  /// Checks if the given type can have a pointer type pointing to it.
+  static bool isValidElementType(Type type);
+  using Base::getChecked;
+  static LLVMPointerType get(::mlir::MLIRContext *context, Type elementType, unsigned addressSpace);
+  static LLVMPointerType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, Type elementType, unsigned addressSpace);
+  static LLVMPointerType get(Type elementType, unsigned addressSpace = 0);
+  static LLVMPointerType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned addressSpace = 0);
+  static LLVMPointerType get(::mlir::MLIRContext *context, unsigned addressSpace = 0);
+  static LLVMPointerType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, unsigned addressSpace = 0);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned addressSpace);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"ptr"};
+  }
+
+  static ::mlir::Type parse(::mlir::AsmParser &odsParser);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  Type getElementType() const;
+  unsigned getAddressSpace() const;
+  unsigned getTypeSizeInBits(const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  unsigned getABIAlignment(const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  unsigned getPreferredAlignment(const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  bool areCompatible(::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout) const;
+  ::mlir::LogicalResult verifyEntries(::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc) const;
+};
+namespace detail {
+struct LLVMScalableVectorTypeStorage;
+} // namespace detail
+class LLVMScalableVectorType : public ::mlir::Type::TypeBase<LLVMScalableVectorType, ::mlir::Type, detail::LLVMScalableVectorTypeStorage, ::mlir::SubElementTypeInterface::Trait> {
+public:
+  using Base::Base;
+  /// Checks if the given type can be used in a vector type.
+  static bool isValidElementType(Type type);
+  using Base::getChecked;
+  static LLVMScalableVectorType get(::mlir::MLIRContext *context, Type elementType, unsigned minNumElements);
+  static LLVMScalableVectorType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, Type elementType, unsigned minNumElements);
+  static LLVMScalableVectorType get(Type elementType, unsigned minNumElements);
+  static LLVMScalableVectorType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned minNumElements);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned minNumElements);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"vec"};
+  }
+
+  static ::mlir::Type parse(::mlir::AsmParser &odsParser);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  Type getElementType() const;
+  unsigned getMinNumElements() const;
+};
+} // namespace LLVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LLVMArrayType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LLVMFixedVectorType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LLVMFunctionType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LLVMPointerType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::LLVM::LLVMScalableVectorType)
+
+#endif  // GET_TYPEDEF_CLASSES
+

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.h.inc
@@ -1,0 +1,2886 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Op Declarations                                                            *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#if defined(GET_OP_CLASSES) || defined(GET_OP_FWD_DEFINES)
+#undef GET_OP_FWD_DEFINES
+namespace mlir {
+namespace NVVM {
+class Barrier0Op;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class BlockDimXOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class BlockDimYOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class BlockDimZOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class BlockIdXOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class BlockIdYOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class BlockIdZOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class CpAsyncCommitGroupOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class CpAsyncOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class CpAsyncWaitGroupOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class GridDimXOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class GridDimYOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class GridDimZOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class LaneIdOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class LdMatrixOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class MmaOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class RcpApproxFtzF32Op;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class ShflOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class SyncWarpOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class ThreadIdXOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class ThreadIdYOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class ThreadIdZOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class VoteBallotOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class WMMALoadOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class WMMAMmaOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class WMMAStoreOp;
+} // namespace NVVM
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class WarpSizeOp;
+} // namespace NVVM
+} // namespace mlir
+#endif
+
+#ifdef GET_OP_CLASSES
+#undef GET_OP_CLASSES
+
+
+//===----------------------------------------------------------------------===//
+// Local Utility Method Definitions
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::Barrier0Op declarations
+//===----------------------------------------------------------------------===//
+
+class Barrier0OpAdaptor {
+public:
+  Barrier0OpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  Barrier0OpAdaptor(Barrier0Op op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class Barrier0Op : public ::mlir::Op<Barrier0Op, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = Barrier0OpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.barrier0");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::Barrier0Op)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::BlockDimXOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockDimXOpAdaptor {
+public:
+  BlockDimXOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockDimXOpAdaptor(BlockDimXOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockDimXOp : public ::mlir::Op<BlockDimXOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockDimXOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.ntid.x");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::BlockDimXOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::BlockDimYOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockDimYOpAdaptor {
+public:
+  BlockDimYOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockDimYOpAdaptor(BlockDimYOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockDimYOp : public ::mlir::Op<BlockDimYOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockDimYOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.ntid.y");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::BlockDimYOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::BlockDimZOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockDimZOpAdaptor {
+public:
+  BlockDimZOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockDimZOpAdaptor(BlockDimZOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockDimZOp : public ::mlir::Op<BlockDimZOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockDimZOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.ntid.z");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::BlockDimZOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::BlockIdXOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockIdXOpAdaptor {
+public:
+  BlockIdXOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockIdXOpAdaptor(BlockIdXOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockIdXOp : public ::mlir::Op<BlockIdXOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockIdXOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.ctaid.x");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::BlockIdXOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::BlockIdYOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockIdYOpAdaptor {
+public:
+  BlockIdYOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockIdYOpAdaptor(BlockIdYOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockIdYOp : public ::mlir::Op<BlockIdYOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockIdYOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.ctaid.y");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::BlockIdYOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::BlockIdZOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockIdZOpAdaptor {
+public:
+  BlockIdZOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockIdZOpAdaptor(BlockIdZOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockIdZOp : public ::mlir::Op<BlockIdZOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockIdZOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.ctaid.z");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::BlockIdZOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::CpAsyncCommitGroupOp declarations
+//===----------------------------------------------------------------------===//
+
+class CpAsyncCommitGroupOpAdaptor {
+public:
+  CpAsyncCommitGroupOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CpAsyncCommitGroupOpAdaptor(CpAsyncCommitGroupOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class CpAsyncCommitGroupOp : public ::mlir::Op<CpAsyncCommitGroupOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CpAsyncCommitGroupOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.cp.async.commit.group");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::CpAsyncCommitGroupOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::CpAsyncOp declarations
+//===----------------------------------------------------------------------===//
+
+class CpAsyncOpAdaptor {
+public:
+  CpAsyncOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CpAsyncOpAdaptor(CpAsyncOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getDst();
+  ::mlir::Value getSrc();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getSizeAttr();
+  uint32_t getSize();
+  ::mlir::UnitAttr getBypassL1Attr();
+  ::llvm::Optional<bool> getBypassL1();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class CpAsyncOp : public ::mlir::Op<CpAsyncOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CpAsyncOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("bypass_l1"), ::llvm::StringRef("size")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getBypassL1AttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getBypassL1AttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getSizeAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getSizeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.cp.async.shared.global");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getDst();
+  ::mlir::Value getSrc();
+  ::mlir::MutableOperandRange getDstMutable();
+  ::mlir::MutableOperandRange getSrcMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::IntegerAttr getSizeAttr();
+  uint32_t getSize();
+  ::mlir::UnitAttr getBypassL1Attr();
+  ::llvm::Optional<bool> getBypassL1();
+  void setSizeAttr(::mlir::IntegerAttr attr);
+  void setSize(uint32_t attrValue);
+  void setBypassL1Attr(::mlir::UnitAttr attr);
+  void setBypassL1(bool attrValue);
+  ::mlir::Attribute removeBypass_l1Attr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value dst, ::mlir::Value src, ::mlir::IntegerAttr size, /*optional*/::mlir::UnitAttr bypass_l1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dst, ::mlir::Value src, ::mlir::IntegerAttr size, /*optional*/::mlir::UnitAttr bypass_l1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value dst, ::mlir::Value src, uint32_t size, /*optional*/::mlir::UnitAttr bypass_l1);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dst, ::mlir::Value src, uint32_t size, /*optional*/::mlir::UnitAttr bypass_l1);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::CpAsyncOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::CpAsyncWaitGroupOp declarations
+//===----------------------------------------------------------------------===//
+
+class CpAsyncWaitGroupOpAdaptor {
+public:
+  CpAsyncWaitGroupOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  CpAsyncWaitGroupOpAdaptor(CpAsyncWaitGroupOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getNAttr();
+  uint32_t getN();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class CpAsyncWaitGroupOp : public ::mlir::Op<CpAsyncWaitGroupOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = CpAsyncWaitGroupOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("n")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getNAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getNAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.cp.async.wait.group");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::IntegerAttr getNAttr();
+  uint32_t getN();
+  void setNAttr(::mlir::IntegerAttr attr);
+  void setN(uint32_t attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::IntegerAttr n);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::IntegerAttr n);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, uint32_t n);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, uint32_t n);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 1 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::CpAsyncWaitGroupOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::GridDimXOp declarations
+//===----------------------------------------------------------------------===//
+
+class GridDimXOpAdaptor {
+public:
+  GridDimXOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GridDimXOpAdaptor(GridDimXOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class GridDimXOp : public ::mlir::Op<GridDimXOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GridDimXOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.nctaid.x");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::GridDimXOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::GridDimYOp declarations
+//===----------------------------------------------------------------------===//
+
+class GridDimYOpAdaptor {
+public:
+  GridDimYOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GridDimYOpAdaptor(GridDimYOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class GridDimYOp : public ::mlir::Op<GridDimYOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GridDimYOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.nctaid.y");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::GridDimYOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::GridDimZOp declarations
+//===----------------------------------------------------------------------===//
+
+class GridDimZOpAdaptor {
+public:
+  GridDimZOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GridDimZOpAdaptor(GridDimZOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class GridDimZOp : public ::mlir::Op<GridDimZOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GridDimZOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.nctaid.z");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::GridDimZOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::LaneIdOp declarations
+//===----------------------------------------------------------------------===//
+
+class LaneIdOpAdaptor {
+public:
+  LaneIdOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LaneIdOpAdaptor(LaneIdOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class LaneIdOp : public ::mlir::Op<LaneIdOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LaneIdOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.laneid");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::LaneIdOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::LdMatrixOp declarations
+//===----------------------------------------------------------------------===//
+
+class LdMatrixOpAdaptor {
+public:
+  LdMatrixOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  LdMatrixOpAdaptor(LdMatrixOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getNumAttr();
+  uint32_t getNum();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAttr();
+  ::mlir::NVVM::MMALayout getLayout();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class LdMatrixOp : public ::mlir::Op<LdMatrixOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = LdMatrixOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("layout"), ::llvm::StringRef("num")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getLayoutAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getLayoutAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getNumAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getNumAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.ldmatrix");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::MutableOperandRange getPtrMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getNumAttr();
+  uint32_t getNum();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAttr();
+  ::mlir::NVVM::MMALayout getLayout();
+  void setNumAttr(::mlir::IntegerAttr attr);
+  void setNum(uint32_t attrValue);
+  void setLayoutAttr(::mlir::NVVM::MMALayoutAttr attr);
+  void setLayout(::mlir::NVVM::MMALayout attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptr, ::mlir::IntegerAttr num, ::mlir::NVVM::MMALayoutAttr layout);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, ::mlir::IntegerAttr num, ::mlir::NVVM::MMALayoutAttr layout);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptr, uint32_t num, ::mlir::NVVM::MMALayout layout);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, uint32_t num, ::mlir::NVVM::MMALayout layout);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::LdMatrixOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::MmaOp declarations
+//===----------------------------------------------------------------------===//
+
+class MmaOpAdaptor {
+public:
+  MmaOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MmaOpAdaptor(MmaOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperandA();
+  ::mlir::ValueRange getOperandB();
+  ::mlir::ValueRange getOperandC();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::NVVM::MMAShapeAttr getShapeAttr();
+  ::mlir::NVVM::MMAShapeAttr getShape();
+  ::mlir::NVVM::MMAB1OpAttr getB1OpAttr();
+  ::llvm::Optional<::mlir::NVVM::MMAB1Op> getB1Op();
+  ::mlir::NVVM::MMAIntOverflowAttr getIntOverflowBehaviorAttr();
+  ::llvm::Optional<::mlir::NVVM::MMAIntOverflow> getIntOverflowBehavior();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAAttr();
+  ::mlir::NVVM::MMALayout getLayoutA();
+  ::mlir::NVVM::MMALayoutAttr getLayoutBAttr();
+  ::mlir::NVVM::MMALayout getLayoutB();
+  ::mlir::NVVM::MMATypesAttr getMultiplicandAPtxTypeAttr();
+  ::llvm::Optional<::mlir::NVVM::MMATypes> getMultiplicandAPtxType();
+  ::mlir::NVVM::MMATypesAttr getMultiplicandBPtxTypeAttr();
+  ::llvm::Optional<::mlir::NVVM::MMATypes> getMultiplicandBPtxType();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class MmaOp : public ::mlir::Op<MmaOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::AttrSizedOperandSegments, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MmaOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("b1Op"), ::llvm::StringRef("intOverflowBehavior"), ::llvm::StringRef("layoutA"), ::llvm::StringRef("layoutB"), ::llvm::StringRef("multiplicandAPtxType"), ::llvm::StringRef("multiplicandBPtxType"), ::llvm::StringRef("operand_segment_sizes"), ::llvm::StringRef("shape")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getB1OpAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getB1OpAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getIntOverflowBehaviorAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getIntOverflowBehaviorAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getLayoutAAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getLayoutAAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getLayoutBAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getLayoutBAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getMultiplicandAPtxTypeAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getMultiplicandAPtxTypeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  ::mlir::StringAttr getMultiplicandBPtxTypeAttrName() {
+    return getAttributeNameForIndex(5);
+  }
+
+  static ::mlir::StringAttr getMultiplicandBPtxTypeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 5);
+  }
+
+  ::mlir::StringAttr getOperandSegmentSizesAttrName() {
+    return getAttributeNameForIndex(6);
+  }
+
+  static ::mlir::StringAttr getOperandSegmentSizesAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 6);
+  }
+
+  ::mlir::StringAttr getShapeAttrName() {
+    return getAttributeNameForIndex(7);
+  }
+
+  static ::mlir::StringAttr getShapeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 7);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.mma.sync");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getOperandA();
+  ::mlir::Operation::operand_range getOperandB();
+  ::mlir::Operation::operand_range getOperandC();
+  ::mlir::MutableOperandRange getOperandAMutable();
+  ::mlir::MutableOperandRange getOperandBMutable();
+  ::mlir::MutableOperandRange getOperandCMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::NVVM::MMAShapeAttr getShapeAttr();
+  ::mlir::NVVM::MMAShapeAttr getShape();
+  ::mlir::NVVM::MMAB1OpAttr getB1OpAttr();
+  ::llvm::Optional<::mlir::NVVM::MMAB1Op> getB1Op();
+  ::mlir::NVVM::MMAIntOverflowAttr getIntOverflowBehaviorAttr();
+  ::llvm::Optional<::mlir::NVVM::MMAIntOverflow> getIntOverflowBehavior();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAAttr();
+  ::mlir::NVVM::MMALayout getLayoutA();
+  ::mlir::NVVM::MMALayoutAttr getLayoutBAttr();
+  ::mlir::NVVM::MMALayout getLayoutB();
+  ::mlir::NVVM::MMATypesAttr getMultiplicandAPtxTypeAttr();
+  ::llvm::Optional<::mlir::NVVM::MMATypes> getMultiplicandAPtxType();
+  ::mlir::NVVM::MMATypesAttr getMultiplicandBPtxTypeAttr();
+  ::llvm::Optional<::mlir::NVVM::MMATypes> getMultiplicandBPtxType();
+  void setShapeAttr(::mlir::NVVM::MMAShapeAttr attr);
+  void setB1OpAttr(::mlir::NVVM::MMAB1OpAttr attr);
+  void setB1Op(::llvm::Optional<::mlir::NVVM::MMAB1Op> attrValue);
+  void setIntOverflowBehaviorAttr(::mlir::NVVM::MMAIntOverflowAttr attr);
+  void setIntOverflowBehavior(::llvm::Optional<::mlir::NVVM::MMAIntOverflow> attrValue);
+  void setLayoutAAttr(::mlir::NVVM::MMALayoutAttr attr);
+  void setLayoutA(::mlir::NVVM::MMALayout attrValue);
+  void setLayoutBAttr(::mlir::NVVM::MMALayoutAttr attr);
+  void setLayoutB(::mlir::NVVM::MMALayout attrValue);
+  void setMultiplicandAPtxTypeAttr(::mlir::NVVM::MMATypesAttr attr);
+  void setMultiplicandAPtxType(::llvm::Optional<::mlir::NVVM::MMATypes> attrValue);
+  void setMultiplicandBPtxTypeAttr(::mlir::NVVM::MMATypesAttr attr);
+  void setMultiplicandBPtxType(::llvm::Optional<::mlir::NVVM::MMATypes> attrValue);
+  ::mlir::Attribute removeB1OpAttr();
+  ::mlir::Attribute removeIntOverflowBehaviorAttr();
+  ::mlir::Attribute removeMultiplicandAPtxTypeAttr();
+  ::mlir::Attribute removeMultiplicandBPtxTypeAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, Type resultType, ValueRange operandA, ValueRange operandB, ValueRange operandC, ArrayRef<int64_t> shape, Optional<MMAB1Op> b1Op, Optional<MMAIntOverflow> intOverflow, Optional<std::array<MMATypes, 2>> multiplicandPtxTypes, Optional<std::array<MMALayout, 2>> multiplicandLayouts);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::NVVM::MMAShapeAttr shape, /*optional*/::mlir::NVVM::MMAB1OpAttr b1Op, /*optional*/::mlir::NVVM::MMAIntOverflowAttr intOverflowBehavior, ::mlir::NVVM::MMALayoutAttr layoutA, ::mlir::NVVM::MMALayoutAttr layoutB, /*optional*/::mlir::NVVM::MMATypesAttr multiplicandAPtxType, /*optional*/::mlir::NVVM::MMATypesAttr multiplicandBPtxType, ::mlir::ValueRange operandA, ::mlir::ValueRange operandB, ::mlir::ValueRange operandC);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::NVVM::MMAShapeAttr shape, /*optional*/::mlir::NVVM::MMAB1OpAttr b1Op, /*optional*/::mlir::NVVM::MMAIntOverflowAttr intOverflowBehavior, ::mlir::NVVM::MMALayoutAttr layoutA, ::mlir::NVVM::MMALayoutAttr layoutB, /*optional*/::mlir::NVVM::MMATypesAttr multiplicandAPtxType, /*optional*/::mlir::NVVM::MMATypesAttr multiplicandBPtxType, ::mlir::ValueRange operandA, ::mlir::ValueRange operandB, ::mlir::ValueRange operandC);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::NVVM::MMAShapeAttr shape, /*optional*/::mlir::NVVM::MMAB1OpAttr b1Op, /*optional*/::mlir::NVVM::MMAIntOverflowAttr intOverflowBehavior, ::mlir::NVVM::MMALayout layoutA, ::mlir::NVVM::MMALayout layoutB, /*optional*/::mlir::NVVM::MMATypesAttr multiplicandAPtxType, /*optional*/::mlir::NVVM::MMATypesAttr multiplicandBPtxType, ::mlir::ValueRange operandA, ::mlir::ValueRange operandB, ::mlir::ValueRange operandC);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::NVVM::MMAShapeAttr shape, /*optional*/::mlir::NVVM::MMAB1OpAttr b1Op, /*optional*/::mlir::NVVM::MMAIntOverflowAttr intOverflowBehavior, ::mlir::NVVM::MMALayout layoutA, ::mlir::NVVM::MMALayout layoutB, /*optional*/::mlir::NVVM::MMATypesAttr multiplicandAPtxType, /*optional*/::mlir::NVVM::MMATypesAttr multiplicandBPtxType, ::mlir::ValueRange operandA, ::mlir::ValueRange operandB, ::mlir::ValueRange operandC);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 8 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+        static llvm::Intrinsic::ID getIntrinsicID(
+              int64_t m, int64_t n, uint64_t k,
+              llvm::Optional<MMAB1Op> b1Op,
+              llvm::Optional<MMAIntOverflow> sat,
+              mlir::NVVM::MMALayout layoutAEnum, mlir::NVVM::MMALayout layoutBEnum,
+              mlir::NVVM::MMATypes eltypeAEnum, mlir::NVVM::MMATypes eltypeBEnum,
+              mlir::NVVM::MMATypes eltypeCEnum, mlir::NVVM::MMATypes eltypeDEnum) {
+          llvm::StringRef layoutA = stringifyEnum(layoutAEnum);
+          llvm::StringRef layoutB = stringifyEnum(layoutBEnum);
+          llvm::StringRef eltypeA = stringifyEnum(eltypeAEnum);
+          llvm::StringRef eltypeB = stringifyEnum(eltypeBEnum);
+          llvm::StringRef eltypeC = stringifyEnum(eltypeCEnum);
+          llvm::StringRef eltypeD = stringifyEnum(eltypeDEnum);
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 4    && "tf32" == eltypeA && "tf32" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k4_row_col_tf32;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 8    && "tf32" == eltypeA && "tf32" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k8_row_col_tf32;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "bf16" == eltypeA && "bf16" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_bf16;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 8    && "bf16" == eltypeA && "bf16" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k8_row_col_bf16;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 4    && "f64" == eltypeA && "f64" == eltypeB &&  "f64" == eltypeC &&  "f64" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_row_col_f64;
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "row" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f16" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_row_row_f16_f16;
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f16" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_row_col_f16_f16;
+
+  if (layoutA == "col" && layoutB == "row" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f16" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_col_row_f16_f16;
+
+  if (layoutA == "col" && layoutB == "col" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f16" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_col_col_f16_f16;
+
+  if (layoutA == "row" && layoutB == "row" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_row_row_f32_f16;
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_row_col_f32_f16;
+
+  if (layoutA == "col" && layoutB == "row" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_col_row_f32_f16;
+
+  if (layoutA == "col" && layoutB == "col" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_col_col_f32_f16;
+
+
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "row" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_row_row_f32_f32;
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_row_col_f32_f32;
+
+  if (layoutA == "col" && layoutB == "row" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_col_row_f32_f32;
+
+  if (layoutA == "col" && layoutB == "col" &&     m == 8 && n == 8 && k == 4    && "f16" == eltypeA && "f16" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k4_col_col_f32_f32;
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 8    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f16" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k8_row_col_f16_f16;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 8    && "f16" == eltypeA && "f16" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k8_row_col_f32_f32;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f16" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_f16_f16;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "f16" == eltypeA && "f16" == eltypeB &&  "f16" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_f32_f16;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "f16" == eltypeA && "f16" == eltypeB &&  "f32" == eltypeC &&  "f16" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_f16_f32;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "f16" == eltypeA && "f16" == eltypeB &&  "f32" == eltypeC &&  "f32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_f32_f32;
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 16    && "s8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k16_row_col_s8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 16    && "s8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k16_row_col_satfinite_s8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 16    && "s8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k16_row_col_s8_u8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 16    && "s8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k16_row_col_satfinite_s8_u8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 16    && "u8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k16_row_col_u8_s8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 16    && "u8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k16_row_col_satfinite_u8_s8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 16    && "u8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k16_row_col_u8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 16    && "u8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k16_row_col_satfinite_u8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "s8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_s8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "s8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_satfinite_s8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "s8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_s8_u8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "s8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_satfinite_s8_u8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "u8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_u8_s8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "u8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_satfinite_u8_s8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "u8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_u8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 16    && "u8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k16_row_col_satfinite_u8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "s8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_s8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "s8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_satfinite_s8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "s8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_s8_u8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "s8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_satfinite_s8_u8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "u8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_u8_s8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "u8" == eltypeA && "s8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_satfinite_u8_s8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "u8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_u8;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "u8" == eltypeA && "u8" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_satfinite_u8;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 32    && "s4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k32_row_col_s4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 32    && "s4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k32_row_col_satfinite_s4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 32    && "s4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k32_row_col_s4_u4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 32    && "s4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k32_row_col_satfinite_s4_u4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 32    && "u4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k32_row_col_u4_s4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 32    && "u4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k32_row_col_satfinite_u4_s4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 32    && "u4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k32_row_col_u4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 32    && "u4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m8n8k32_row_col_satfinite_u4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "s4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_s4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "s4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_satfinite_s4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "s4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_s4_u4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "s4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_satfinite_s4_u4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "u4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_u4_s4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "u4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_satfinite_u4_s4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "u4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_u4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 32    && "u4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k32_row_col_satfinite_u4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 64    && "s4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k64_row_col_s4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 64    && "s4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k64_row_col_satfinite_s4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 64    && "s4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k64_row_col_s4_u4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 64    && "s4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k64_row_col_satfinite_s4_u4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 64    && "u4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k64_row_col_u4_s4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 64    && "u4" == eltypeA && "s4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k64_row_col_satfinite_u4_s4;
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 64    && "u4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k64_row_col_u4;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 64    && "u4" == eltypeA && "u4" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 1 == static_cast<int>(*sat) : true))
+    return llvm::Intrinsic::nvvm_mma_m16n8k64_row_col_satfinite_u4;
+
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 128    && "b1" == eltypeA && "b1" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true) && (b1Op.has_value() ? MMAB1Op::xor_popc == b1Op.value() : true))
+    return llvm::Intrinsic::nvvm_mma_xor_popc_m8n8k128_row_col_b1;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 8 && k == 128    && "b1" == eltypeA && "b1" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true) && (b1Op.has_value() ? MMAB1Op::and_popc == b1Op.value() : true))
+    return llvm::Intrinsic::nvvm_mma_and_popc_m8n8k128_row_col_b1;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 128    && "b1" == eltypeA && "b1" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true) && (b1Op.has_value() ? MMAB1Op::xor_popc == b1Op.value() : true))
+    return llvm::Intrinsic::nvvm_mma_xor_popc_m16n8k128_row_col_b1;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 128    && "b1" == eltypeA && "b1" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true) && (b1Op.has_value() ? MMAB1Op::and_popc == b1Op.value() : true))
+    return llvm::Intrinsic::nvvm_mma_and_popc_m16n8k128_row_col_b1;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 256    && "b1" == eltypeA && "b1" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true) && (b1Op.has_value() ? MMAB1Op::xor_popc == b1Op.value() : true))
+    return llvm::Intrinsic::nvvm_mma_xor_popc_m16n8k256_row_col_b1;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 8 && k == 256    && "b1" == eltypeA && "b1" == eltypeB &&  "s32" == eltypeC &&  "s32" == eltypeD  && (sat.has_value()  ? 0 == static_cast<int>(*sat) : true) && (b1Op.has_value() ? MMAB1Op::and_popc == b1Op.value() : true))
+    return llvm::Intrinsic::nvvm_mma_and_popc_m16n8k256_row_col_b1;
+
+
+
+
+
+
+
+
+
+
+          return 0;
+        }
+
+        static Optional<mlir::NVVM::MMATypes> inferOperandMMAType(Type operandElType,
+          bool isAccumulator);
+
+        MMATypes accumPtxType();
+        MMATypes resultPtxType();
+      };
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::MmaOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::RcpApproxFtzF32Op declarations
+//===----------------------------------------------------------------------===//
+
+class RcpApproxFtzF32OpAdaptor {
+public:
+  RcpApproxFtzF32OpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  RcpApproxFtzF32OpAdaptor(RcpApproxFtzF32Op op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getArg();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class RcpApproxFtzF32Op : public ::mlir::Op<RcpApproxFtzF32Op, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::FloatType>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = RcpApproxFtzF32OpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.rcp.approx.ftz.f");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::FloatType> getArg();
+  ::mlir::MutableOperandRange getArgMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::TypedValue<::mlir::FloatType> getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value arg);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::RcpApproxFtzF32Op)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::ShflOp declarations
+//===----------------------------------------------------------------------===//
+
+class ShflOpAdaptor {
+public:
+  ShflOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ShflOpAdaptor(ShflOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getDst();
+  ::mlir::Value getVal();
+  ::mlir::Value getOffset();
+  ::mlir::Value getMaskAndClamp();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::NVVM::ShflKindAttr getKindAttr();
+  ::mlir::NVVM::ShflKind getKind();
+  ::mlir::UnitAttr getReturnValueAndIsValidAttr();
+  ::llvm::Optional<bool> getReturnValueAndIsValid();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class ShflOp : public ::mlir::Op<ShflOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ShflOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("kind"), ::llvm::StringRef("return_value_and_is_valid")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getKindAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getKindAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getReturnValueAndIsValidAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getReturnValueAndIsValidAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.shfl.sync");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::IntegerType> getDst();
+  ::mlir::Value getVal();
+  ::mlir::TypedValue<::mlir::IntegerType> getOffset();
+  ::mlir::TypedValue<::mlir::IntegerType> getMaskAndClamp();
+  ::mlir::MutableOperandRange getDstMutable();
+  ::mlir::MutableOperandRange getValMutable();
+  ::mlir::MutableOperandRange getOffsetMutable();
+  ::mlir::MutableOperandRange getMaskAndClampMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::NVVM::ShflKindAttr getKindAttr();
+  ::mlir::NVVM::ShflKind getKind();
+  ::mlir::UnitAttr getReturnValueAndIsValidAttr();
+  ::llvm::Optional<bool> getReturnValueAndIsValid();
+  void setKindAttr(::mlir::NVVM::ShflKindAttr attr);
+  void setKind(::mlir::NVVM::ShflKind attrValue);
+  void setReturnValueAndIsValidAttr(::mlir::UnitAttr attr);
+  void setReturnValueAndIsValid(bool attrValue);
+  ::mlir::Attribute removeReturn_value_and_is_validAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value dst, ::mlir::Value val, ::mlir::Value offset, ::mlir::Value mask_and_clamp, ::mlir::NVVM::ShflKindAttr kind, /*optional*/::mlir::UnitAttr return_value_and_is_valid);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dst, ::mlir::Value val, ::mlir::Value offset, ::mlir::Value mask_and_clamp, ::mlir::NVVM::ShflKindAttr kind, /*optional*/::mlir::UnitAttr return_value_and_is_valid);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value dst, ::mlir::Value val, ::mlir::Value offset, ::mlir::Value mask_and_clamp, ::mlir::NVVM::ShflKind kind, /*optional*/::mlir::UnitAttr return_value_and_is_valid);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value dst, ::mlir::Value val, ::mlir::Value offset, ::mlir::Value mask_and_clamp, ::mlir::NVVM::ShflKind kind, /*optional*/::mlir::UnitAttr return_value_and_is_valid);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::ShflOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::SyncWarpOp declarations
+//===----------------------------------------------------------------------===//
+
+class SyncWarpOpAdaptor {
+public:
+  SyncWarpOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  SyncWarpOpAdaptor(SyncWarpOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getMask();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class SyncWarpOp : public ::mlir::Op<SyncWarpOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = SyncWarpOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.bar.warp.sync");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getMask();
+  ::mlir::MutableOperandRange getMaskMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value mask);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value mask);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::SyncWarpOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::ThreadIdXOp declarations
+//===----------------------------------------------------------------------===//
+
+class ThreadIdXOpAdaptor {
+public:
+  ThreadIdXOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ThreadIdXOpAdaptor(ThreadIdXOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class ThreadIdXOp : public ::mlir::Op<ThreadIdXOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ThreadIdXOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.tid.x");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::ThreadIdXOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::ThreadIdYOp declarations
+//===----------------------------------------------------------------------===//
+
+class ThreadIdYOpAdaptor {
+public:
+  ThreadIdYOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ThreadIdYOpAdaptor(ThreadIdYOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class ThreadIdYOp : public ::mlir::Op<ThreadIdYOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ThreadIdYOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.tid.y");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::ThreadIdYOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::ThreadIdZOp declarations
+//===----------------------------------------------------------------------===//
+
+class ThreadIdZOpAdaptor {
+public:
+  ThreadIdZOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ThreadIdZOpAdaptor(ThreadIdZOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class ThreadIdZOp : public ::mlir::Op<ThreadIdZOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ThreadIdZOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.tid.z");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::ThreadIdZOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::VoteBallotOp declarations
+//===----------------------------------------------------------------------===//
+
+class VoteBallotOpAdaptor {
+public:
+  VoteBallotOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  VoteBallotOpAdaptor(VoteBallotOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getMask();
+  ::mlir::Value getPred();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class VoteBallotOp : public ::mlir::Op<VoteBallotOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = VoteBallotOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.vote.ballot.sync");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getMask();
+  ::mlir::Value getPred();
+  ::mlir::MutableOperandRange getMaskMutable();
+  ::mlir::MutableOperandRange getPredMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value mask, ::mlir::Value pred);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value mask, ::mlir::Value pred);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::VoteBallotOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::WMMALoadOp declarations
+//===----------------------------------------------------------------------===//
+
+class WMMALoadOpAdaptor {
+public:
+  WMMALoadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  WMMALoadOpAdaptor(WMMALoadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::Value getStride();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getMAttr();
+  uint32_t getM();
+  ::mlir::IntegerAttr getNAttr();
+  uint32_t getN();
+  ::mlir::IntegerAttr getKAttr();
+  uint32_t getK();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAttr();
+  ::mlir::NVVM::MMALayout getLayout();
+  ::mlir::NVVM::MMATypesAttr getEltypeAttr();
+  ::mlir::NVVM::MMATypes getEltype();
+  ::mlir::NVVM::MMAFragAttr getFragAttr();
+  ::mlir::NVVM::MMAFrag getFrag();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class WMMALoadOp : public ::mlir::Op<WMMALoadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = WMMALoadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("eltype"), ::llvm::StringRef("frag"), ::llvm::StringRef("k"), ::llvm::StringRef("layout"), ::llvm::StringRef("m"), ::llvm::StringRef("n")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getEltypeAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getEltypeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getFragAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getFragAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getKAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getKAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getLayoutAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getLayoutAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getMAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getMAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  ::mlir::StringAttr getNAttrName() {
+    return getAttributeNameForIndex(5);
+  }
+
+  static ::mlir::StringAttr getNAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 5);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.wmma.load");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::TypedValue<::mlir::IntegerType> getStride();
+  ::mlir::MutableOperandRange getPtrMutable();
+  ::mlir::MutableOperandRange getStrideMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getMAttr();
+  uint32_t getM();
+  ::mlir::IntegerAttr getNAttr();
+  uint32_t getN();
+  ::mlir::IntegerAttr getKAttr();
+  uint32_t getK();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAttr();
+  ::mlir::NVVM::MMALayout getLayout();
+  ::mlir::NVVM::MMATypesAttr getEltypeAttr();
+  ::mlir::NVVM::MMATypes getEltype();
+  ::mlir::NVVM::MMAFragAttr getFragAttr();
+  ::mlir::NVVM::MMAFrag getFrag();
+  void setMAttr(::mlir::IntegerAttr attr);
+  void setM(uint32_t attrValue);
+  void setNAttr(::mlir::IntegerAttr attr);
+  void setN(uint32_t attrValue);
+  void setKAttr(::mlir::IntegerAttr attr);
+  void setK(uint32_t attrValue);
+  void setLayoutAttr(::mlir::NVVM::MMALayoutAttr attr);
+  void setLayout(::mlir::NVVM::MMALayout attrValue);
+  void setEltypeAttr(::mlir::NVVM::MMATypesAttr attr);
+  void setEltype(::mlir::NVVM::MMATypes attrValue);
+  void setFragAttr(::mlir::NVVM::MMAFragAttr attr);
+  void setFrag(::mlir::NVVM::MMAFrag attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptr, ::mlir::Value stride, ::mlir::IntegerAttr m, ::mlir::IntegerAttr n, ::mlir::IntegerAttr k, ::mlir::NVVM::MMALayoutAttr layout, ::mlir::NVVM::MMATypesAttr eltype, ::mlir::NVVM::MMAFragAttr frag);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, ::mlir::Value stride, ::mlir::IntegerAttr m, ::mlir::IntegerAttr n, ::mlir::IntegerAttr k, ::mlir::NVVM::MMALayoutAttr layout, ::mlir::NVVM::MMATypesAttr eltype, ::mlir::NVVM::MMAFragAttr frag);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value ptr, ::mlir::Value stride, uint32_t m, uint32_t n, uint32_t k, ::mlir::NVVM::MMALayout layout, ::mlir::NVVM::MMATypes eltype, ::mlir::NVVM::MMAFrag frag);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, ::mlir::Value stride, uint32_t m, uint32_t n, uint32_t k, ::mlir::NVVM::MMALayout layout, ::mlir::NVVM::MMATypes eltype, ::mlir::NVVM::MMAFrag frag);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 6 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  static llvm::Intrinsic::ID getIntrinsicID(int m, int n, int k, mlir::NVVM::MMALayout layoutEnum,mlir::NVVM::MMATypes eltypeEnum,mlir::NVVM::MMAFrag fragEnum) {llvm::StringRef layout = stringifyEnum(layoutEnum);llvm::StringRef eltype = stringifyEnum(eltypeEnum);llvm::StringRef frag = stringifyEnum(fragEnum);
+
+  if (layout == "row" && m == 16 &&    n == 16 && k == 16 && "f16" == eltype && frag == "a")  return llvm::Intrinsic::nvvm_wmma_m16n16k16_load_a_f16_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 16 && "f16" == eltype && frag == "a")  return llvm::Intrinsic::nvvm_wmma_m16n16k16_load_a_f16_col_stride;
+  if (layout == "row" && m == 16 &&    n == 16 && k == 16 && "f16" == eltype && frag == "b")  return llvm::Intrinsic::nvvm_wmma_m16n16k16_load_b_f16_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 16 && "f16" == eltype && frag == "b")  return llvm::Intrinsic::nvvm_wmma_m16n16k16_load_b_f16_col_stride;
+  if (layout == "row" && m == 32 &&    n == 8 && k == 16 && "f16" == eltype && frag == "a")  return llvm::Intrinsic::nvvm_wmma_m32n8k16_load_a_f16_row_stride;
+  if (layout == "col" && m == 32 &&    n == 8 && k == 16 && "f16" == eltype && frag == "a")  return llvm::Intrinsic::nvvm_wmma_m32n8k16_load_a_f16_col_stride;
+  if (layout == "row" && m == 32 &&    n == 8 && k == 16 && "f16" == eltype && frag == "b")  return llvm::Intrinsic::nvvm_wmma_m32n8k16_load_b_f16_row_stride;
+  if (layout == "col" && m == 32 &&    n == 8 && k == 16 && "f16" == eltype && frag == "b")  return llvm::Intrinsic::nvvm_wmma_m32n8k16_load_b_f16_col_stride;
+  if (layout == "row" && m == 8 &&    n == 32 && k == 16 && "f16" == eltype && frag == "a")  return llvm::Intrinsic::nvvm_wmma_m8n32k16_load_a_f16_row_stride;
+  if (layout == "col" && m == 8 &&    n == 32 && k == 16 && "f16" == eltype && frag == "a")  return llvm::Intrinsic::nvvm_wmma_m8n32k16_load_a_f16_col_stride;
+  if (layout == "row" && m == 8 &&    n == 32 && k == 16 && "f16" == eltype && frag == "b")  return llvm::Intrinsic::nvvm_wmma_m8n32k16_load_b_f16_row_stride;
+  if (layout == "col" && m == 8 &&    n == 32 && k == 16 && "f16" == eltype && frag == "b")  return llvm::Intrinsic::nvvm_wmma_m8n32k16_load_b_f16_col_stride;
+  if (layout == "row" && m == 16 &&    n == 16 && k == 16 && "f16" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m16n16k16_load_c_f16_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 16 && "f16" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m16n16k16_load_c_f16_col_stride;
+  if (layout == "row" && m == 16 &&    n == 16 && k == 16 && "f32" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m16n16k16_load_c_f32_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 16 && "f32" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m16n16k16_load_c_f32_col_stride;
+  if (layout == "row" && m == 32 &&    n == 8 && k == 16 && "f16" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m32n8k16_load_c_f16_row_stride;
+  if (layout == "col" && m == 32 &&    n == 8 && k == 16 && "f16" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m32n8k16_load_c_f16_col_stride;
+  if (layout == "row" && m == 32 &&    n == 8 && k == 16 && "f32" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m32n8k16_load_c_f32_row_stride;
+  if (layout == "col" && m == 32 &&    n == 8 && k == 16 && "f32" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m32n8k16_load_c_f32_col_stride;
+  if (layout == "row" && m == 8 &&    n == 32 && k == 16 && "f16" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m8n32k16_load_c_f16_row_stride;
+  if (layout == "col" && m == 8 &&    n == 32 && k == 16 && "f16" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m8n32k16_load_c_f16_col_stride;
+  if (layout == "row" && m == 8 &&    n == 32 && k == 16 && "f32" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m8n32k16_load_c_f32_row_stride;
+  if (layout == "col" && m == 8 &&    n == 32 && k == 16 && "f32" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m8n32k16_load_c_f32_col_stride;
+  if (layout == "row" && m == 16 &&    n == 16 && k == 8 && "tf32" == eltype && frag == "a")  return llvm::Intrinsic::nvvm_wmma_m16n16k8_load_a_tf32_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 8 && "tf32" == eltype && frag == "a")  return llvm::Intrinsic::nvvm_wmma_m16n16k8_load_a_tf32_col_stride;
+  if (layout == "row" && m == 16 &&    n == 16 && k == 8 && "tf32" == eltype && frag == "b")  return llvm::Intrinsic::nvvm_wmma_m16n16k8_load_b_tf32_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 8 && "tf32" == eltype && frag == "b")  return llvm::Intrinsic::nvvm_wmma_m16n16k8_load_b_tf32_col_stride;
+  if (layout == "row" && m == 16 &&    n == 16 && k == 8 && "f32" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m16n16k8_load_c_f32_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 8 && "f32" == eltype && frag == "c")  return llvm::Intrinsic::nvvm_wmma_m16n16k8_load_c_f32_col_stride;
+  return 0;}
+  /// Helpers to find valid n dimension based on mxk load shape.
+  static int inferNDimension(int m, int k, mlir::NVVM::MMATypes eltypeEnum) {  llvm::StringRef eltype = stringifyEnum(eltypeEnum);
+  if (m == 16 && k == 16 && "f16" == eltype)  return 16;
+  if (m == 32 && k == 16 && "f16" == eltype)  return 8;
+  if (m == 8 && k == 16 && "f16" == eltype)  return 32;
+  if (m == 16 && k == 8 && "tf32" == eltype)  return 16;
+  return 0;}
+  /// Helpers to find valid m dimension based on kxn load shape.
+  static int inferMDimension(int k, int n, mlir::NVVM::MMATypes eltypeEnum) {  llvm::StringRef eltype = stringifyEnum(eltypeEnum);
+  if (n == 16 && k == 16 && "f16" == eltype)  return 16;
+  if (n == 8 && k == 16 && "f16" == eltype)  return 32;
+  if (n == 32 && k == 16 && "f16" == eltype)  return 8;
+  if (n == 16 && k == 8 && "tf32" == eltype)  return 16;
+  return 0;}
+  /// Helpers to find valid k dimension based on mxn load shape.
+  static int inferKDimension(int m, int n, mlir::NVVM::MMATypes eltypeEnum) {  llvm::StringRef eltype = stringifyEnum(eltypeEnum);
+  if (m == 16 && n == 16 && "f16" == eltype)  return 16;
+  if (m == 16 && n == 16 && "f32" == eltype)  return 16;
+  if (m == 32 && n == 8 && "f16" == eltype)  return 16;
+  if (m == 32 && n == 8 && "f32" == eltype)  return 16;
+  if (m == 8 && n == 32 && "f16" == eltype)  return 16;
+  if (m == 8 && n == 32 && "f32" == eltype)  return 16;
+  if (m == 16 && n == 16 && "f32" == eltype)  return 8;
+  return 0;}
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::WMMALoadOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::WMMAMmaOp declarations
+//===----------------------------------------------------------------------===//
+
+class WMMAMmaOpAdaptor {
+public:
+  WMMAMmaOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  WMMAMmaOpAdaptor(WMMAMmaOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getMAttr();
+  uint32_t getM();
+  ::mlir::IntegerAttr getNAttr();
+  uint32_t getN();
+  ::mlir::IntegerAttr getKAttr();
+  uint32_t getK();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAAttr();
+  ::mlir::NVVM::MMALayout getLayoutA();
+  ::mlir::NVVM::MMALayoutAttr getLayoutBAttr();
+  ::mlir::NVVM::MMALayout getLayoutB();
+  ::mlir::NVVM::MMATypesAttr getEltypeAAttr();
+  ::mlir::NVVM::MMATypes getEltypeA();
+  ::mlir::NVVM::MMATypesAttr getEltypeBAttr();
+  ::mlir::NVVM::MMATypes getEltypeB();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class WMMAMmaOp : public ::mlir::Op<WMMAMmaOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = WMMAMmaOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("eltypeA"), ::llvm::StringRef("eltypeB"), ::llvm::StringRef("k"), ::llvm::StringRef("layoutA"), ::llvm::StringRef("layoutB"), ::llvm::StringRef("m"), ::llvm::StringRef("n")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getEltypeAAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getEltypeAAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getEltypeBAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getEltypeBAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getKAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getKAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getLayoutAAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getLayoutAAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getLayoutBAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getLayoutBAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  ::mlir::StringAttr getMAttrName() {
+    return getAttributeNameForIndex(5);
+  }
+
+  static ::mlir::StringAttr getMAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 5);
+  }
+
+  ::mlir::StringAttr getNAttrName() {
+    return getAttributeNameForIndex(6);
+  }
+
+  static ::mlir::StringAttr getNAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 6);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.wmma.mma");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  ::mlir::IntegerAttr getMAttr();
+  uint32_t getM();
+  ::mlir::IntegerAttr getNAttr();
+  uint32_t getN();
+  ::mlir::IntegerAttr getKAttr();
+  uint32_t getK();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAAttr();
+  ::mlir::NVVM::MMALayout getLayoutA();
+  ::mlir::NVVM::MMALayoutAttr getLayoutBAttr();
+  ::mlir::NVVM::MMALayout getLayoutB();
+  ::mlir::NVVM::MMATypesAttr getEltypeAAttr();
+  ::mlir::NVVM::MMATypes getEltypeA();
+  ::mlir::NVVM::MMATypesAttr getEltypeBAttr();
+  ::mlir::NVVM::MMATypes getEltypeB();
+  void setMAttr(::mlir::IntegerAttr attr);
+  void setM(uint32_t attrValue);
+  void setNAttr(::mlir::IntegerAttr attr);
+  void setN(uint32_t attrValue);
+  void setKAttr(::mlir::IntegerAttr attr);
+  void setK(uint32_t attrValue);
+  void setLayoutAAttr(::mlir::NVVM::MMALayoutAttr attr);
+  void setLayoutA(::mlir::NVVM::MMALayout attrValue);
+  void setLayoutBAttr(::mlir::NVVM::MMALayoutAttr attr);
+  void setLayoutB(::mlir::NVVM::MMALayout attrValue);
+  void setEltypeAAttr(::mlir::NVVM::MMATypesAttr attr);
+  void setEltypeA(::mlir::NVVM::MMATypes attrValue);
+  void setEltypeBAttr(::mlir::NVVM::MMATypesAttr attr);
+  void setEltypeB(::mlir::NVVM::MMATypes attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::IntegerAttr m, ::mlir::IntegerAttr n, ::mlir::IntegerAttr k, ::mlir::NVVM::MMALayoutAttr layoutA, ::mlir::NVVM::MMALayoutAttr layoutB, ::mlir::NVVM::MMATypesAttr eltypeA, ::mlir::NVVM::MMATypesAttr eltypeB, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::IntegerAttr m, ::mlir::IntegerAttr n, ::mlir::IntegerAttr k, ::mlir::NVVM::MMALayoutAttr layoutA, ::mlir::NVVM::MMALayoutAttr layoutB, ::mlir::NVVM::MMATypesAttr eltypeA, ::mlir::NVVM::MMATypesAttr eltypeB, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, uint32_t m, uint32_t n, uint32_t k, ::mlir::NVVM::MMALayout layoutA, ::mlir::NVVM::MMALayout layoutB, ::mlir::NVVM::MMATypes eltypeA, ::mlir::NVVM::MMATypes eltypeB, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, uint32_t m, uint32_t n, uint32_t k, ::mlir::NVVM::MMALayout layoutA, ::mlir::NVVM::MMALayout layoutB, ::mlir::NVVM::MMATypes eltypeA, ::mlir::NVVM::MMATypes eltypeB, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 7 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  static llvm::Intrinsic::ID getIntrinsicID(int m, int n, int k, mlir::NVVM::MMALayout layoutAEnum,mlir::NVVM::MMALayout layoutBEnum, mlir::NVVM::MMATypes eltypeAEnum,mlir::NVVM::MMATypes eltypeBEnum) {llvm::StringRef layoutA = stringifyEnum(layoutAEnum);llvm::StringRef layoutB = stringifyEnum(layoutBEnum);llvm::StringRef eltypeA = stringifyEnum(eltypeAEnum);llvm::StringRef eltypeB = stringifyEnum(eltypeBEnum);
+
+
+  if (layoutA == "row" && layoutB == "row" &&     m == 16 && n == 16 && k == 8    && "tf32" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k8_mma_row_row_tf32;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 16 && k == 8    && "tf32" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k8_mma_row_col_tf32;
+  if (layoutA == "col" && layoutB == "row" &&     m == 16 && n == 16 && k == 8    && "tf32" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k8_mma_col_row_tf32;
+  if (layoutA == "col" && layoutB == "col" &&     m == 16 && n == 16 && k == 8    && "tf32" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k8_mma_col_col_tf32;
+  if (layoutA == "row" && layoutB == "row" &&     m == 16 && n == 16 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_mma_row_row_f16_f16;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 16 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_mma_row_col_f16_f16;
+  if (layoutA == "col" && layoutB == "row" &&     m == 16 && n == 16 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_mma_col_row_f16_f16;
+  if (layoutA == "col" && layoutB == "col" &&     m == 16 && n == 16 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_mma_col_col_f16_f16;
+  if (layoutA == "row" && layoutB == "row" &&     m == 16 && n == 16 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_mma_row_row_f32_f32;
+  if (layoutA == "row" && layoutB == "col" &&     m == 16 && n == 16 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_mma_row_col_f32_f32;
+  if (layoutA == "col" && layoutB == "row" &&     m == 16 && n == 16 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_mma_col_row_f32_f32;
+  if (layoutA == "col" && layoutB == "col" &&     m == 16 && n == 16 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_mma_col_col_f32_f32;
+  if (layoutA == "row" && layoutB == "row" &&     m == 32 && n == 8 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_mma_row_row_f16_f16;
+  if (layoutA == "row" && layoutB == "col" &&     m == 32 && n == 8 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_mma_row_col_f16_f16;
+  if (layoutA == "col" && layoutB == "row" &&     m == 32 && n == 8 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_mma_col_row_f16_f16;
+  if (layoutA == "col" && layoutB == "col" &&     m == 32 && n == 8 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_mma_col_col_f16_f16;
+  if (layoutA == "row" && layoutB == "row" &&     m == 32 && n == 8 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_mma_row_row_f32_f32;
+  if (layoutA == "row" && layoutB == "col" &&     m == 32 && n == 8 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_mma_row_col_f32_f32;
+  if (layoutA == "col" && layoutB == "row" &&     m == 32 && n == 8 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_mma_col_row_f32_f32;
+  if (layoutA == "col" && layoutB == "col" &&     m == 32 && n == 8 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_mma_col_col_f32_f32;
+  if (layoutA == "row" && layoutB == "row" &&     m == 8 && n == 32 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_mma_row_row_f16_f16;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 32 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_mma_row_col_f16_f16;
+  if (layoutA == "col" && layoutB == "row" &&     m == 8 && n == 32 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_mma_col_row_f16_f16;
+  if (layoutA == "col" && layoutB == "col" &&     m == 8 && n == 32 && k == 16    && "f16" == eltypeA && "f16" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_mma_col_col_f16_f16;
+  if (layoutA == "row" && layoutB == "row" &&     m == 8 && n == 32 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_mma_row_row_f32_f32;
+  if (layoutA == "row" && layoutB == "col" &&     m == 8 && n == 32 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_mma_row_col_f32_f32;
+  if (layoutA == "col" && layoutB == "row" &&     m == 8 && n == 32 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_mma_col_row_f32_f32;
+  if (layoutA == "col" && layoutB == "col" &&     m == 8 && n == 32 && k == 16    && "f16" == eltypeA && "f32" == eltypeB)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_mma_col_col_f32_f32;
+  return 0;}};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::WMMAMmaOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::WMMAStoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class WMMAStoreOpAdaptor {
+public:
+  WMMAStoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  WMMAStoreOpAdaptor(WMMAStoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getPtr();
+  ::mlir::ValueRange getArgs();
+  ::mlir::Value getStride();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::IntegerAttr getMAttr();
+  uint32_t getM();
+  ::mlir::IntegerAttr getNAttr();
+  uint32_t getN();
+  ::mlir::IntegerAttr getKAttr();
+  uint32_t getK();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAttr();
+  ::mlir::NVVM::MMALayout getLayout();
+  ::mlir::NVVM::MMATypesAttr getEltypeAttr();
+  ::mlir::NVVM::MMATypes getEltype();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class WMMAStoreOp : public ::mlir::Op<WMMAStoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::AtLeastNOperands<2>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = WMMAStoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("eltype"), ::llvm::StringRef("k"), ::llvm::StringRef("layout"), ::llvm::StringRef("m"), ::llvm::StringRef("n")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getEltypeAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getEltypeAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getKAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getKAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  ::mlir::StringAttr getLayoutAttrName() {
+    return getAttributeNameForIndex(2);
+  }
+
+  static ::mlir::StringAttr getLayoutAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 2);
+  }
+
+  ::mlir::StringAttr getMAttrName() {
+    return getAttributeNameForIndex(3);
+  }
+
+  static ::mlir::StringAttr getMAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 3);
+  }
+
+  ::mlir::StringAttr getNAttrName() {
+    return getAttributeNameForIndex(4);
+  }
+
+  static ::mlir::StringAttr getNAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 4);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.wmma.store");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::TypedValue<::mlir::LLVM::LLVMPointerType> getPtr();
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::TypedValue<::mlir::IntegerType> getStride();
+  ::mlir::MutableOperandRange getPtrMutable();
+  ::mlir::MutableOperandRange getArgsMutable();
+  ::mlir::MutableOperandRange getStrideMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::IntegerAttr getMAttr();
+  uint32_t getM();
+  ::mlir::IntegerAttr getNAttr();
+  uint32_t getN();
+  ::mlir::IntegerAttr getKAttr();
+  uint32_t getK();
+  ::mlir::NVVM::MMALayoutAttr getLayoutAttr();
+  ::mlir::NVVM::MMALayout getLayout();
+  ::mlir::NVVM::MMATypesAttr getEltypeAttr();
+  ::mlir::NVVM::MMATypes getEltype();
+  void setMAttr(::mlir::IntegerAttr attr);
+  void setM(uint32_t attrValue);
+  void setNAttr(::mlir::IntegerAttr attr);
+  void setN(uint32_t attrValue);
+  void setKAttr(::mlir::IntegerAttr attr);
+  void setK(uint32_t attrValue);
+  void setLayoutAttr(::mlir::NVVM::MMALayoutAttr attr);
+  void setLayout(::mlir::NVVM::MMALayout attrValue);
+  void setEltypeAttr(::mlir::NVVM::MMATypesAttr attr);
+  void setEltype(::mlir::NVVM::MMATypes attrValue);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value ptr, ::mlir::IntegerAttr m, ::mlir::IntegerAttr n, ::mlir::IntegerAttr k, ::mlir::NVVM::MMALayoutAttr layout, ::mlir::NVVM::MMATypesAttr eltype, ::mlir::ValueRange args, ::mlir::Value stride);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, ::mlir::IntegerAttr m, ::mlir::IntegerAttr n, ::mlir::IntegerAttr k, ::mlir::NVVM::MMALayoutAttr layout, ::mlir::NVVM::MMATypesAttr eltype, ::mlir::ValueRange args, ::mlir::Value stride);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value ptr, uint32_t m, uint32_t n, uint32_t k, ::mlir::NVVM::MMALayout layout, ::mlir::NVVM::MMATypes eltype, ::mlir::ValueRange args, ::mlir::Value stride);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value ptr, uint32_t m, uint32_t n, uint32_t k, ::mlir::NVVM::MMALayout layout, ::mlir::NVVM::MMATypes eltype, ::mlir::ValueRange args, ::mlir::Value stride);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 5 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  static llvm::Intrinsic::ID getIntrinsicID(int m, int n, int k, mlir::NVVM::MMALayout layoutEnum,mlir::NVVM::MMATypes eltypeEnum) {  llvm::StringRef layout = stringifyEnum(layoutEnum);  llvm::StringRef eltype = stringifyEnum(eltypeEnum);
+
+  if (layout == "row" && m == 16 &&    n == 16 && k == 16 && "f16" == eltype)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_store_d_f16_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 16 && "f16" == eltype)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_store_d_f16_col_stride;
+  if (layout == "row" && m == 16 &&    n == 16 && k == 16 && "f32" == eltype)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_store_d_f32_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 16 && "f32" == eltype)  return llvm::Intrinsic::nvvm_wmma_m16n16k16_store_d_f32_col_stride;
+  if (layout == "row" && m == 32 &&    n == 8 && k == 16 && "f16" == eltype)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_store_d_f16_row_stride;
+  if (layout == "col" && m == 32 &&    n == 8 && k == 16 && "f16" == eltype)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_store_d_f16_col_stride;
+  if (layout == "row" && m == 32 &&    n == 8 && k == 16 && "f32" == eltype)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_store_d_f32_row_stride;
+  if (layout == "col" && m == 32 &&    n == 8 && k == 16 && "f32" == eltype)  return llvm::Intrinsic::nvvm_wmma_m32n8k16_store_d_f32_col_stride;
+  if (layout == "row" && m == 8 &&    n == 32 && k == 16 && "f16" == eltype)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_store_d_f16_row_stride;
+  if (layout == "col" && m == 8 &&    n == 32 && k == 16 && "f16" == eltype)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_store_d_f16_col_stride;
+  if (layout == "row" && m == 8 &&    n == 32 && k == 16 && "f32" == eltype)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_store_d_f32_row_stride;
+  if (layout == "col" && m == 8 &&    n == 32 && k == 16 && "f32" == eltype)  return llvm::Intrinsic::nvvm_wmma_m8n32k16_store_d_f32_col_stride;
+  if (layout == "row" && m == 16 &&    n == 16 && k == 8 && "f32" == eltype)  return llvm::Intrinsic::nvvm_wmma_m16n16k8_store_d_f32_row_stride;
+  if (layout == "col" && m == 16 &&    n == 16 && k == 8 && "f32" == eltype)  return llvm::Intrinsic::nvvm_wmma_m16n16k8_store_d_f32_col_stride;
+  return 0;}
+  /// Helpers to find valid k dimension based on mxn store shape.
+  static int inferKDimension(int m, int n, mlir::NVVM::MMATypes eltypeEnum) {  llvm::StringRef eltype = stringifyEnum(eltypeEnum);
+  if (m == 16 && n == 16 && "f16" == eltype)  return 16;
+  if (m == 16 && n == 16 && "f32" == eltype)  return 16;
+  if (m == 32 && n == 8 && "f16" == eltype)  return 16;
+  if (m == 32 && n == 8 && "f32" == eltype)  return 16;
+  if (m == 8 && n == 32 && "f16" == eltype)  return 16;
+  if (m == 8 && n == 32 && "f32" == eltype)  return 16;
+  if (m == 16 && n == 16 && "f32" == eltype)  return 8;
+  return 0;}};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::WMMAStoreOp)
+
+namespace mlir {
+namespace NVVM {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::NVVM::WarpSizeOp declarations
+//===----------------------------------------------------------------------===//
+
+class WarpSizeOpAdaptor {
+public:
+  WarpSizeOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  WarpSizeOpAdaptor(WarpSizeOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class WarpSizeOp : public ::mlir::Op<WarpSizeOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = WarpSizeOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("nvvm.read.ptx.sreg.warpsize");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::WarpSizeOp)
+
+
+#endif  // GET_OP_CLASSES
+

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOpsAttributes.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOpsAttributes.h.inc
@@ -1,0 +1,144 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* AttrDef Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifdef GET_ATTRDEF_CLASSES
+#undef GET_ATTRDEF_CLASSES
+
+
+namespace mlir {
+class AsmParser;
+class AsmPrinter;
+} // namespace mlir
+namespace mlir {
+namespace NVVM {
+class MMAB1OpAttr;
+class MMAFragAttr;
+class MMAIntOverflowAttr;
+class MMALayoutAttr;
+class MMATypesAttr;
+class MMAShapeAttr;
+class ShflKindAttr;
+namespace detail {
+struct MMAB1OpAttrStorage;
+} // namespace detail
+class MMAB1OpAttr : public ::mlir::Attribute::AttrBase<MMAB1OpAttr, ::mlir::Attribute, detail::MMAB1OpAttrStorage> {
+public:
+  using Base::Base;
+  static MMAB1OpAttr get(::mlir::MLIRContext *context, ::mlir::NVVM::MMAB1Op value);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"mma_b1op"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  ::mlir::NVVM::MMAB1Op getValue() const;
+};
+namespace detail {
+struct MMAFragAttrStorage;
+} // namespace detail
+class MMAFragAttr : public ::mlir::Attribute::AttrBase<MMAFragAttr, ::mlir::Attribute, detail::MMAFragAttrStorage> {
+public:
+  using Base::Base;
+  static MMAFragAttr get(::mlir::MLIRContext *context, ::mlir::NVVM::MMAFrag value);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"mma_frag"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  ::mlir::NVVM::MMAFrag getValue() const;
+};
+namespace detail {
+struct MMAIntOverflowAttrStorage;
+} // namespace detail
+class MMAIntOverflowAttr : public ::mlir::Attribute::AttrBase<MMAIntOverflowAttr, ::mlir::Attribute, detail::MMAIntOverflowAttrStorage> {
+public:
+  using Base::Base;
+  static MMAIntOverflowAttr get(::mlir::MLIRContext *context, ::mlir::NVVM::MMAIntOverflow value);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"mma_int_overflow"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  ::mlir::NVVM::MMAIntOverflow getValue() const;
+};
+namespace detail {
+struct MMALayoutAttrStorage;
+} // namespace detail
+class MMALayoutAttr : public ::mlir::Attribute::AttrBase<MMALayoutAttr, ::mlir::Attribute, detail::MMALayoutAttrStorage> {
+public:
+  using Base::Base;
+  static MMALayoutAttr get(::mlir::MLIRContext *context, ::mlir::NVVM::MMALayout value);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"mma_layout"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  ::mlir::NVVM::MMALayout getValue() const;
+};
+namespace detail {
+struct MMATypesAttrStorage;
+} // namespace detail
+class MMATypesAttr : public ::mlir::Attribute::AttrBase<MMATypesAttr, ::mlir::Attribute, detail::MMATypesAttrStorage> {
+public:
+  using Base::Base;
+  static MMATypesAttr get(::mlir::MLIRContext *context, ::mlir::NVVM::MMATypes value);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"mma_type"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  ::mlir::NVVM::MMATypes getValue() const;
+};
+namespace detail {
+struct MMAShapeAttrStorage;
+} // namespace detail
+class MMAShapeAttr : public ::mlir::Attribute::AttrBase<MMAShapeAttr, ::mlir::Attribute, detail::MMAShapeAttrStorage> {
+public:
+  using Base::Base;
+  static MMAShapeAttr get(::mlir::MLIRContext *context, int m, int n, int k);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"shape"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  int getM() const;
+  int getN() const;
+  int getK() const;
+};
+namespace detail {
+struct ShflKindAttrStorage;
+} // namespace detail
+class ShflKindAttr : public ::mlir::Attribute::AttrBase<ShflKindAttr, ::mlir::Attribute, detail::ShflKindAttrStorage> {
+public:
+  using Base::Base;
+  static ShflKindAttr get(::mlir::MLIRContext *context, ::mlir::NVVM::ShflKind value);
+  static constexpr ::llvm::StringLiteral getMnemonic() {
+    return {"shfl_kind"};
+  }
+
+  static ::mlir::Attribute parse(::mlir::AsmParser &odsParser, ::mlir::Type odsType);
+  void print(::mlir::AsmPrinter &odsPrinter) const;
+  ::mlir::NVVM::ShflKind getValue() const;
+};
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::MMAB1OpAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::MMAFragAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::MMAIntOverflowAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::MMALayoutAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::MMATypesAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::MMAShapeAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::ShflKindAttr)
+
+#endif  // GET_ATTRDEF_CLASSES
+

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOpsDialect.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOpsDialect.h.inc
@@ -1,0 +1,65 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Dialect Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+namespace NVVM {
+
+class NVVMDialect : public ::mlir::Dialect {
+  explicit NVVMDialect(::mlir::MLIRContext *context);
+
+  void initialize();
+  friend class ::mlir::MLIRContext;
+public:
+  ~NVVMDialect() override;
+  static constexpr ::llvm::StringLiteral getDialectNamespace() {
+    return ::llvm::StringLiteral("nvvm");
+  }
+
+  /// Parse an attribute registered to this dialect.
+  ::mlir::Attribute parseAttribute(::mlir::DialectAsmParser &parser,
+                                   ::mlir::Type type) const override;
+
+  /// Print an attribute registered to this dialect.
+  void printAttribute(::mlir::Attribute attr,
+                      ::mlir::DialectAsmPrinter &os) const override;
+
+    /// Provides a hook for verifying dialect attributes attached to the given
+    /// op.
+    ::mlir::LogicalResult verifyOperationAttribute(
+        ::mlir::Operation *op, ::mlir::NamedAttribute attribute) override;
+
+    /// Get the name of the attribute used to annotate external kernel
+    /// functions.
+    static StringRef getKernelFuncAttrName() { return "nvvm.kernel"; }
+    /// Get the name of the attribute used to annotate max threads required
+    /// per CTA for kernel functions.
+    static StringRef getMaxntidAttrName() { return "nvvm.maxntid"; }
+    /// Get the name of the metadata names for each dimension
+    static StringRef getMaxntidXName() { return "maxntidx"; }
+    static StringRef getMaxntidYName() { return "maxntidy"; }
+    static StringRef getMaxntidZName() { return "maxntidz"; }
+
+    /// Get the name of the attribute used to annotate exact threads required
+    /// per CTA for kernel functions.
+    static StringRef getReqntidAttrName() { return "nvvm.reqntid"; }
+    /// Get the name of the metadata names for each dimension
+    static StringRef getReqntidXName() { return "reqntidx"; }
+    static StringRef getReqntidYName() { return "reqntidy"; }
+    static StringRef getReqntidZName() { return "reqntidz"; }
+
+    /// Get the name of the attribute used to annotate min CTA required
+    /// per SM for kernel functions.
+    static StringRef getMinctasmAttrName() { return "nvvm.minctasm"; }
+
+    /// Get the name of the attribute used to annotate max number of
+    /// registers that can be allocated per thread.
+    static StringRef getMaxnregAttrName() { return "nvvm.maxnreg"; }
+  };
+} // namespace NVVM
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NVVM::NVVMDialect)

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOpsEnums.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOpsEnums.h.inc
@@ -1,0 +1,507 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Enum Utility Declarations                                                  *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+namespace NVVM {
+// MMA binary operations
+enum class MMAB1Op : uint32_t {
+  none = 0,
+  xor_popc = 1,
+  and_popc = 2,
+};
+
+::llvm::Optional<MMAB1Op> symbolizeMMAB1Op(uint32_t);
+::llvm::StringRef stringifyMMAB1Op(MMAB1Op);
+::llvm::Optional<MMAB1Op> symbolizeMMAB1Op(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForMMAB1Op() {
+  return 2;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(MMAB1Op enumValue) {
+  return stringifyMMAB1Op(enumValue);
+}
+
+template <typename EnumType>
+::llvm::Optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::llvm::Optional<MMAB1Op> symbolizeEnum<MMAB1Op>(::llvm::StringRef str) {
+  return symbolizeMMAB1Op(str);
+}
+} // namespace NVVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::NVVM::MMAB1Op, ::mlir::NVVM::MMAB1Op> {
+  template <typename ParserT>
+  static FailureOr<::mlir::NVVM::MMAB1Op> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for MMA binary operations");
+
+    // Symbolize the keyword.
+    if (::llvm::Optional<::mlir::NVVM::MMAB1Op> attr = ::mlir::NVVM::symbolizeEnum<::mlir::NVVM::MMAB1Op>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid MMA binary operations specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::NVVM::MMAB1Op value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::NVVM::MMAB1Op> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::NVVM::MMAB1Op getEmptyKey() {
+    return static_cast<::mlir::NVVM::MMAB1Op>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::NVVM::MMAB1Op getTombstoneKey() {
+    return static_cast<::mlir::NVVM::MMAB1Op>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::NVVM::MMAB1Op &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::NVVM::MMAB1Op &lhs, const ::mlir::NVVM::MMAB1Op &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace NVVM {
+// NVVM MMA frag type
+enum class MMAFrag : uint32_t {
+  a = 0,
+  b = 1,
+  c = 2,
+};
+
+::llvm::Optional<MMAFrag> symbolizeMMAFrag(uint32_t);
+::llvm::StringRef stringifyMMAFrag(MMAFrag);
+::llvm::Optional<MMAFrag> symbolizeMMAFrag(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForMMAFrag() {
+  return 2;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(MMAFrag enumValue) {
+  return stringifyMMAFrag(enumValue);
+}
+
+template <typename EnumType>
+::llvm::Optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::llvm::Optional<MMAFrag> symbolizeEnum<MMAFrag>(::llvm::StringRef str) {
+  return symbolizeMMAFrag(str);
+}
+} // namespace NVVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::NVVM::MMAFrag, ::mlir::NVVM::MMAFrag> {
+  template <typename ParserT>
+  static FailureOr<::mlir::NVVM::MMAFrag> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for NVVM MMA frag type");
+
+    // Symbolize the keyword.
+    if (::llvm::Optional<::mlir::NVVM::MMAFrag> attr = ::mlir::NVVM::symbolizeEnum<::mlir::NVVM::MMAFrag>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid NVVM MMA frag type specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::NVVM::MMAFrag value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::NVVM::MMAFrag> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::NVVM::MMAFrag getEmptyKey() {
+    return static_cast<::mlir::NVVM::MMAFrag>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::NVVM::MMAFrag getTombstoneKey() {
+    return static_cast<::mlir::NVVM::MMAFrag>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::NVVM::MMAFrag &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::NVVM::MMAFrag &lhs, const ::mlir::NVVM::MMAFrag &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace NVVM {
+// MMA overflow options
+enum class MMAIntOverflow : uint32_t {
+  satfinite = 1,
+  wrapped = 0,
+};
+
+::llvm::Optional<MMAIntOverflow> symbolizeMMAIntOverflow(uint32_t);
+::llvm::StringRef stringifyMMAIntOverflow(MMAIntOverflow);
+::llvm::Optional<MMAIntOverflow> symbolizeMMAIntOverflow(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForMMAIntOverflow() {
+  return 1;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(MMAIntOverflow enumValue) {
+  return stringifyMMAIntOverflow(enumValue);
+}
+
+template <typename EnumType>
+::llvm::Optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::llvm::Optional<MMAIntOverflow> symbolizeEnum<MMAIntOverflow>(::llvm::StringRef str) {
+  return symbolizeMMAIntOverflow(str);
+}
+} // namespace NVVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::NVVM::MMAIntOverflow, ::mlir::NVVM::MMAIntOverflow> {
+  template <typename ParserT>
+  static FailureOr<::mlir::NVVM::MMAIntOverflow> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for MMA overflow options");
+
+    // Symbolize the keyword.
+    if (::llvm::Optional<::mlir::NVVM::MMAIntOverflow> attr = ::mlir::NVVM::symbolizeEnum<::mlir::NVVM::MMAIntOverflow>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid MMA overflow options specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::NVVM::MMAIntOverflow value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::NVVM::MMAIntOverflow> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::NVVM::MMAIntOverflow getEmptyKey() {
+    return static_cast<::mlir::NVVM::MMAIntOverflow>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::NVVM::MMAIntOverflow getTombstoneKey() {
+    return static_cast<::mlir::NVVM::MMAIntOverflow>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::NVVM::MMAIntOverflow &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::NVVM::MMAIntOverflow &lhs, const ::mlir::NVVM::MMAIntOverflow &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace NVVM {
+// NVVM MMA layout
+enum class MMALayout : uint32_t {
+  row = 0,
+  col = 1,
+};
+
+::llvm::Optional<MMALayout> symbolizeMMALayout(uint32_t);
+::llvm::StringRef stringifyMMALayout(MMALayout);
+::llvm::Optional<MMALayout> symbolizeMMALayout(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForMMALayout() {
+  return 1;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(MMALayout enumValue) {
+  return stringifyMMALayout(enumValue);
+}
+
+template <typename EnumType>
+::llvm::Optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::llvm::Optional<MMALayout> symbolizeEnum<MMALayout>(::llvm::StringRef str) {
+  return symbolizeMMALayout(str);
+}
+} // namespace NVVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::NVVM::MMALayout, ::mlir::NVVM::MMALayout> {
+  template <typename ParserT>
+  static FailureOr<::mlir::NVVM::MMALayout> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for NVVM MMA layout");
+
+    // Symbolize the keyword.
+    if (::llvm::Optional<::mlir::NVVM::MMALayout> attr = ::mlir::NVVM::symbolizeEnum<::mlir::NVVM::MMALayout>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid NVVM MMA layout specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::NVVM::MMALayout value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::NVVM::MMALayout> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::NVVM::MMALayout getEmptyKey() {
+    return static_cast<::mlir::NVVM::MMALayout>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::NVVM::MMALayout getTombstoneKey() {
+    return static_cast<::mlir::NVVM::MMALayout>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::NVVM::MMALayout &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::NVVM::MMALayout &lhs, const ::mlir::NVVM::MMALayout &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace NVVM {
+// NVVM MMA types
+enum class MMATypes : uint32_t {
+  f16 = 0,
+  f32 = 1,
+  tf32 = 2,
+  bf16 = 9,
+  s8 = 4,
+  u8 = 3,
+  s32 = 5,
+  s4 = 8,
+  u4 = 7,
+  b1 = 6,
+  f64 = 10,
+};
+
+::llvm::Optional<MMATypes> symbolizeMMATypes(uint32_t);
+::llvm::StringRef stringifyMMATypes(MMATypes);
+::llvm::Optional<MMATypes> symbolizeMMATypes(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForMMATypes() {
+  return 10;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(MMATypes enumValue) {
+  return stringifyMMATypes(enumValue);
+}
+
+template <typename EnumType>
+::llvm::Optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::llvm::Optional<MMATypes> symbolizeEnum<MMATypes>(::llvm::StringRef str) {
+  return symbolizeMMATypes(str);
+}
+} // namespace NVVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::NVVM::MMATypes, ::mlir::NVVM::MMATypes> {
+  template <typename ParserT>
+  static FailureOr<::mlir::NVVM::MMATypes> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for NVVM MMA types");
+
+    // Symbolize the keyword.
+    if (::llvm::Optional<::mlir::NVVM::MMATypes> attr = ::mlir::NVVM::symbolizeEnum<::mlir::NVVM::MMATypes>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid NVVM MMA types specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::NVVM::MMATypes value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::NVVM::MMATypes> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::NVVM::MMATypes getEmptyKey() {
+    return static_cast<::mlir::NVVM::MMATypes>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::NVVM::MMATypes getTombstoneKey() {
+    return static_cast<::mlir::NVVM::MMATypes>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::NVVM::MMATypes &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::NVVM::MMATypes &lhs, const ::mlir::NVVM::MMATypes &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+
+namespace mlir {
+namespace NVVM {
+// NVVM shuffle kind
+enum class ShflKind : uint32_t {
+  bfly = 0,
+  up = 1,
+  down = 2,
+  idx = 3,
+};
+
+::llvm::Optional<ShflKind> symbolizeShflKind(uint32_t);
+::llvm::StringRef stringifyShflKind(ShflKind);
+::llvm::Optional<ShflKind> symbolizeShflKind(::llvm::StringRef);
+inline constexpr unsigned getMaxEnumValForShflKind() {
+  return 3;
+}
+
+
+inline ::llvm::StringRef stringifyEnum(ShflKind enumValue) {
+  return stringifyShflKind(enumValue);
+}
+
+template <typename EnumType>
+::llvm::Optional<EnumType> symbolizeEnum(::llvm::StringRef);
+
+template <>
+inline ::llvm::Optional<ShflKind> symbolizeEnum<ShflKind>(::llvm::StringRef str) {
+  return symbolizeShflKind(str);
+}
+} // namespace NVVM
+} // namespace mlir
+
+namespace mlir {
+template <typename T, typename>
+struct FieldParser;
+
+template<>
+struct FieldParser<::mlir::NVVM::ShflKind, ::mlir::NVVM::ShflKind> {
+  template <typename ParserT>
+  static FailureOr<::mlir::NVVM::ShflKind> parse(ParserT &parser) {
+    // Parse the keyword/string containing the enum.
+    std::string enumKeyword;
+    auto loc = parser.getCurrentLocation();
+    if (failed(parser.parseOptionalKeywordOrString(&enumKeyword)))
+      return parser.emitError(loc, "expected keyword for NVVM shuffle kind");
+
+    // Symbolize the keyword.
+    if (::llvm::Optional<::mlir::NVVM::ShflKind> attr = ::mlir::NVVM::symbolizeEnum<::mlir::NVVM::ShflKind>(enumKeyword))
+      return *attr;
+    return parser.emitError(loc, "invalid NVVM shuffle kind specification: ") << enumKeyword;
+  }
+};
+} // namespace mlir
+
+namespace llvm {
+inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::mlir::NVVM::ShflKind value) {
+  auto valueStr = stringifyEnum(value);
+  return p << valueStr;
+}
+} // namespace llvm
+
+namespace llvm {
+template<> struct DenseMapInfo<::mlir::NVVM::ShflKind> {
+  using StorageInfo = ::llvm::DenseMapInfo<uint32_t>;
+
+  static inline ::mlir::NVVM::ShflKind getEmptyKey() {
+    return static_cast<::mlir::NVVM::ShflKind>(StorageInfo::getEmptyKey());
+  }
+
+  static inline ::mlir::NVVM::ShflKind getTombstoneKey() {
+    return static_cast<::mlir::NVVM::ShflKind>(StorageInfo::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const ::mlir::NVVM::ShflKind &val) {
+    return StorageInfo::getHashValue(static_cast<uint32_t>(val));
+  }
+
+  static bool isEqual(const ::mlir::NVVM::ShflKind &lhs, const ::mlir::NVVM::ShflKind &rhs) {
+    return lhs == rhs;
+  }
+};
+}
+

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.h.inc
@@ -1,0 +1,3108 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Op Declarations                                                            *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#if defined(GET_OP_CLASSES) || defined(GET_OP_FWD_DEFINES)
+#undef GET_OP_FWD_DEFINES
+namespace mlir {
+namespace ROCDL {
+class BarrierOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class BlockDimXOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class BlockDimYOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class BlockDimZOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class BlockIdXOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class BlockIdYOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class BlockIdZOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class GridDimXOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class GridDimYOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class GridDimZOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class MubufLoadOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class MubufStoreOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class RawBufferAtomicFAddOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class RawBufferLoadOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class RawBufferStoreOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class ThreadIdXOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class ThreadIdYOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class ThreadIdZOp;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x16bf16_1k;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x16f16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x1f32;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x2bf16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x4bf16_1k;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x4f16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x4f32;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x8_xf32;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_16x16x8bf16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x1f32;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x2bf16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x2f32;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x4_xf32;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x4bf16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x4bf16_1k;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x4f16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x8bf16_1k;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_32x32x8f16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_4x4x1f32;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_4x4x2bf16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_4x4x4bf16_1k;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f32_4x4x4f16;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f64_16x16x4f64;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_f64_4x4x4f64;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_i32_16x16x16i8;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_i32_16x16x32_i8;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_i32_16x16x4i8;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_i32_32x32x16_i8;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_i32_32x32x4i8;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_i32_32x32x8i8;
+} // namespace ROCDL
+} // namespace mlir
+namespace mlir {
+namespace ROCDL {
+class mfma_i32_4x4x4i8;
+} // namespace ROCDL
+} // namespace mlir
+#endif
+
+#ifdef GET_OP_CLASSES
+#undef GET_OP_CLASSES
+
+
+//===----------------------------------------------------------------------===//
+// Local Utility Method Definitions
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::BarrierOp declarations
+//===----------------------------------------------------------------------===//
+
+class BarrierOpAdaptor {
+public:
+  BarrierOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BarrierOpAdaptor(BarrierOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BarrierOp : public ::mlir::Op<BarrierOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BarrierOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.barrier");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::BarrierOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::BlockDimXOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockDimXOpAdaptor {
+public:
+  BlockDimXOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockDimXOpAdaptor(BlockDimXOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockDimXOp : public ::mlir::Op<BlockDimXOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockDimXOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workgroup.dim.x");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::BlockDimXOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::BlockDimYOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockDimYOpAdaptor {
+public:
+  BlockDimYOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockDimYOpAdaptor(BlockDimYOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockDimYOp : public ::mlir::Op<BlockDimYOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockDimYOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workgroup.dim.y");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::BlockDimYOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::BlockDimZOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockDimZOpAdaptor {
+public:
+  BlockDimZOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockDimZOpAdaptor(BlockDimZOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockDimZOp : public ::mlir::Op<BlockDimZOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockDimZOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workgroup.dim.z");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::BlockDimZOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::BlockIdXOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockIdXOpAdaptor {
+public:
+  BlockIdXOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockIdXOpAdaptor(BlockIdXOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockIdXOp : public ::mlir::Op<BlockIdXOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockIdXOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workgroup.id.x");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::BlockIdXOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::BlockIdYOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockIdYOpAdaptor {
+public:
+  BlockIdYOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockIdYOpAdaptor(BlockIdYOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockIdYOp : public ::mlir::Op<BlockIdYOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockIdYOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workgroup.id.y");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::BlockIdYOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::BlockIdZOp declarations
+//===----------------------------------------------------------------------===//
+
+class BlockIdZOpAdaptor {
+public:
+  BlockIdZOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  BlockIdZOpAdaptor(BlockIdZOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class BlockIdZOp : public ::mlir::Op<BlockIdZOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = BlockIdZOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workgroup.id.z");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::BlockIdZOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::GridDimXOp declarations
+//===----------------------------------------------------------------------===//
+
+class GridDimXOpAdaptor {
+public:
+  GridDimXOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GridDimXOpAdaptor(GridDimXOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class GridDimXOp : public ::mlir::Op<GridDimXOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GridDimXOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.grid.dim.x");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::GridDimXOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::GridDimYOp declarations
+//===----------------------------------------------------------------------===//
+
+class GridDimYOpAdaptor {
+public:
+  GridDimYOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GridDimYOpAdaptor(GridDimYOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class GridDimYOp : public ::mlir::Op<GridDimYOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GridDimYOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.grid.dim.y");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::GridDimYOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::GridDimZOp declarations
+//===----------------------------------------------------------------------===//
+
+class GridDimZOpAdaptor {
+public:
+  GridDimZOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  GridDimZOpAdaptor(GridDimZOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class GridDimZOp : public ::mlir::Op<GridDimZOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = GridDimZOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.grid.dim.z");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::GridDimZOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::MubufLoadOp declarations
+//===----------------------------------------------------------------------===//
+
+class MubufLoadOpAdaptor {
+public:
+  MubufLoadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MubufLoadOpAdaptor(MubufLoadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getRsrc();
+  ::mlir::Value getVindex();
+  ::mlir::Value getOffset();
+  ::mlir::Value getGlc();
+  ::mlir::Value getSlc();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class MubufLoadOp : public ::mlir::Op<MubufLoadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<5>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MubufLoadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.buffer.load");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getRsrc();
+  ::mlir::Value getVindex();
+  ::mlir::Value getOffset();
+  ::mlir::Value getGlc();
+  ::mlir::Value getSlc();
+  ::mlir::MutableOperandRange getRsrcMutable();
+  ::mlir::MutableOperandRange getVindexMutable();
+  ::mlir::MutableOperandRange getOffsetMutable();
+  ::mlir::MutableOperandRange getGlcMutable();
+  ::mlir::MutableOperandRange getSlcMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value rsrc, ::mlir::Value vindex, ::mlir::Value offset, ::mlir::Value glc, ::mlir::Value slc);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value rsrc, ::mlir::Value vindex, ::mlir::Value offset, ::mlir::Value glc, ::mlir::Value slc);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::MubufLoadOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::MubufStoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class MubufStoreOpAdaptor {
+public:
+  MubufStoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  MubufStoreOpAdaptor(MubufStoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVdata();
+  ::mlir::Value getRsrc();
+  ::mlir::Value getVindex();
+  ::mlir::Value getOffset();
+  ::mlir::Value getGlc();
+  ::mlir::Value getSlc();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class MubufStoreOp : public ::mlir::Op<MubufStoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<6>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = MubufStoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.buffer.store");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVdata();
+  ::mlir::Value getRsrc();
+  ::mlir::Value getVindex();
+  ::mlir::Value getOffset();
+  ::mlir::Value getGlc();
+  ::mlir::Value getSlc();
+  ::mlir::MutableOperandRange getVdataMutable();
+  ::mlir::MutableOperandRange getRsrcMutable();
+  ::mlir::MutableOperandRange getVindexMutable();
+  ::mlir::MutableOperandRange getOffsetMutable();
+  ::mlir::MutableOperandRange getGlcMutable();
+  ::mlir::MutableOperandRange getSlcMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value vdata, ::mlir::Value rsrc, ::mlir::Value vindex, ::mlir::Value offset, ::mlir::Value glc, ::mlir::Value slc);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value vdata, ::mlir::Value rsrc, ::mlir::Value vindex, ::mlir::Value offset, ::mlir::Value glc, ::mlir::Value slc);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::MubufStoreOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::RawBufferAtomicFAddOp declarations
+//===----------------------------------------------------------------------===//
+
+class RawBufferAtomicFAddOpAdaptor {
+public:
+  RawBufferAtomicFAddOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  RawBufferAtomicFAddOpAdaptor(RawBufferAtomicFAddOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVdata();
+  ::mlir::Value getRsrc();
+  ::mlir::Value getOffset();
+  ::mlir::Value getSoffset();
+  ::mlir::Value getAux();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class RawBufferAtomicFAddOp : public ::mlir::Op<RawBufferAtomicFAddOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<5>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = RawBufferAtomicFAddOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.raw.buffer.atomic.fadd");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVdata();
+  ::mlir::Value getRsrc();
+  ::mlir::Value getOffset();
+  ::mlir::Value getSoffset();
+  ::mlir::Value getAux();
+  ::mlir::MutableOperandRange getVdataMutable();
+  ::mlir::MutableOperandRange getRsrcMutable();
+  ::mlir::MutableOperandRange getOffsetMutable();
+  ::mlir::MutableOperandRange getSoffsetMutable();
+  ::mlir::MutableOperandRange getAuxMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value vdata, ::mlir::Value rsrc, ::mlir::Value offset, ::mlir::Value soffset, ::mlir::Value aux);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value vdata, ::mlir::Value rsrc, ::mlir::Value offset, ::mlir::Value soffset, ::mlir::Value aux);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::RawBufferAtomicFAddOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::RawBufferLoadOp declarations
+//===----------------------------------------------------------------------===//
+
+class RawBufferLoadOpAdaptor {
+public:
+  RawBufferLoadOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  RawBufferLoadOpAdaptor(RawBufferLoadOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getRsrc();
+  ::mlir::Value getOffset();
+  ::mlir::Value getSoffset();
+  ::mlir::Value getAux();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class RawBufferLoadOp : public ::mlir::Op<RawBufferLoadOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<4>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = RawBufferLoadOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.raw.buffer.load");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getRsrc();
+  ::mlir::Value getOffset();
+  ::mlir::Value getSoffset();
+  ::mlir::Value getAux();
+  ::mlir::MutableOperandRange getRsrcMutable();
+  ::mlir::MutableOperandRange getOffsetMutable();
+  ::mlir::MutableOperandRange getSoffsetMutable();
+  ::mlir::MutableOperandRange getAuxMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::Value rsrc, ::mlir::Value offset, ::mlir::Value soffset, ::mlir::Value aux);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value rsrc, ::mlir::Value offset, ::mlir::Value soffset, ::mlir::Value aux);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::RawBufferLoadOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::RawBufferStoreOp declarations
+//===----------------------------------------------------------------------===//
+
+class RawBufferStoreOpAdaptor {
+public:
+  RawBufferStoreOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  RawBufferStoreOpAdaptor(RawBufferStoreOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::Value getVdata();
+  ::mlir::Value getRsrc();
+  ::mlir::Value getOffset();
+  ::mlir::Value getSoffset();
+  ::mlir::Value getAux();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class RawBufferStoreOp : public ::mlir::Op<RawBufferStoreOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::NOperands<5>::Impl, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = RawBufferStoreOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.raw.buffer.store");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Value getVdata();
+  ::mlir::Value getRsrc();
+  ::mlir::Value getOffset();
+  ::mlir::Value getSoffset();
+  ::mlir::Value getAux();
+  ::mlir::MutableOperandRange getVdataMutable();
+  ::mlir::MutableOperandRange getRsrcMutable();
+  ::mlir::MutableOperandRange getOffsetMutable();
+  ::mlir::MutableOperandRange getSoffsetMutable();
+  ::mlir::MutableOperandRange getAuxMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Value vdata, ::mlir::Value rsrc, ::mlir::Value offset, ::mlir::Value soffset, ::mlir::Value aux);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::Value vdata, ::mlir::Value rsrc, ::mlir::Value offset, ::mlir::Value soffset, ::mlir::Value aux);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &p);
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::RawBufferStoreOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::ThreadIdXOp declarations
+//===----------------------------------------------------------------------===//
+
+class ThreadIdXOpAdaptor {
+public:
+  ThreadIdXOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ThreadIdXOpAdaptor(ThreadIdXOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class ThreadIdXOp : public ::mlir::Op<ThreadIdXOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ThreadIdXOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workitem.id.x");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::ThreadIdXOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::ThreadIdYOp declarations
+//===----------------------------------------------------------------------===//
+
+class ThreadIdYOpAdaptor {
+public:
+  ThreadIdYOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ThreadIdYOpAdaptor(ThreadIdYOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class ThreadIdYOp : public ::mlir::Op<ThreadIdYOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ThreadIdYOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workitem.id.y");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::ThreadIdYOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::ThreadIdZOp declarations
+//===----------------------------------------------------------------------===//
+
+class ThreadIdZOpAdaptor {
+public:
+  ThreadIdZOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ThreadIdZOpAdaptor(ThreadIdZOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class ThreadIdZOp : public ::mlir::Op<ThreadIdZOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::OpInvariants, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ThreadIdZOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.workitem.id.z");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res);
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::ThreadIdZOp)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x16bf16_1k declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x16bf16_1kAdaptor {
+public:
+  mfma_f32_16x16x16bf16_1kAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x16bf16_1kAdaptor(mfma_f32_16x16x16bf16_1k op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x16bf16_1k : public ::mlir::Op<mfma_f32_16x16x16bf16_1k, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x16bf16_1kAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x16bf16.1k");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x16bf16_1k)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x16f16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x16f16Adaptor {
+public:
+  mfma_f32_16x16x16f16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x16f16Adaptor(mfma_f32_16x16x16f16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x16f16 : public ::mlir::Op<mfma_f32_16x16x16f16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x16f16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x16f16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x16f16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x1f32 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x1f32Adaptor {
+public:
+  mfma_f32_16x16x1f32Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x1f32Adaptor(mfma_f32_16x16x1f32 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x1f32 : public ::mlir::Op<mfma_f32_16x16x1f32, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x1f32Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x1f32");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x1f32)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x2bf16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x2bf16Adaptor {
+public:
+  mfma_f32_16x16x2bf16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x2bf16Adaptor(mfma_f32_16x16x2bf16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x2bf16 : public ::mlir::Op<mfma_f32_16x16x2bf16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x2bf16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x2bf16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x2bf16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x4bf16_1k declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x4bf16_1kAdaptor {
+public:
+  mfma_f32_16x16x4bf16_1kAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x4bf16_1kAdaptor(mfma_f32_16x16x4bf16_1k op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x4bf16_1k : public ::mlir::Op<mfma_f32_16x16x4bf16_1k, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x4bf16_1kAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x4bf16.1k");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x4bf16_1k)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x4f16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x4f16Adaptor {
+public:
+  mfma_f32_16x16x4f16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x4f16Adaptor(mfma_f32_16x16x4f16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x4f16 : public ::mlir::Op<mfma_f32_16x16x4f16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x4f16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x4f16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x4f16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x4f32 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x4f32Adaptor {
+public:
+  mfma_f32_16x16x4f32Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x4f32Adaptor(mfma_f32_16x16x4f32 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x4f32 : public ::mlir::Op<mfma_f32_16x16x4f32, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x4f32Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x4f32");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x4f32)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x8_xf32 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x8_xf32Adaptor {
+public:
+  mfma_f32_16x16x8_xf32Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x8_xf32Adaptor(mfma_f32_16x16x8_xf32 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x8_xf32 : public ::mlir::Op<mfma_f32_16x16x8_xf32, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x8_xf32Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x8.xf32");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x8_xf32)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_16x16x8bf16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_16x16x8bf16Adaptor {
+public:
+  mfma_f32_16x16x8bf16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_16x16x8bf16Adaptor(mfma_f32_16x16x8bf16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_16x16x8bf16 : public ::mlir::Op<mfma_f32_16x16x8bf16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_16x16x8bf16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.16x16x8bf16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_16x16x8bf16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x1f32 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x1f32Adaptor {
+public:
+  mfma_f32_32x32x1f32Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x1f32Adaptor(mfma_f32_32x32x1f32 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x1f32 : public ::mlir::Op<mfma_f32_32x32x1f32, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x1f32Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x1f32");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x1f32)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x2bf16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x2bf16Adaptor {
+public:
+  mfma_f32_32x32x2bf16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x2bf16Adaptor(mfma_f32_32x32x2bf16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x2bf16 : public ::mlir::Op<mfma_f32_32x32x2bf16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x2bf16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x2bf16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x2bf16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x2f32 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x2f32Adaptor {
+public:
+  mfma_f32_32x32x2f32Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x2f32Adaptor(mfma_f32_32x32x2f32 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x2f32 : public ::mlir::Op<mfma_f32_32x32x2f32, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x2f32Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x2f32");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x2f32)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x4_xf32 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x4_xf32Adaptor {
+public:
+  mfma_f32_32x32x4_xf32Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x4_xf32Adaptor(mfma_f32_32x32x4_xf32 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x4_xf32 : public ::mlir::Op<mfma_f32_32x32x4_xf32, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x4_xf32Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x4.xf32");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x4_xf32)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x4bf16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x4bf16Adaptor {
+public:
+  mfma_f32_32x32x4bf16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x4bf16Adaptor(mfma_f32_32x32x4bf16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x4bf16 : public ::mlir::Op<mfma_f32_32x32x4bf16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x4bf16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x4bf16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x4bf16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x4bf16_1k declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x4bf16_1kAdaptor {
+public:
+  mfma_f32_32x32x4bf16_1kAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x4bf16_1kAdaptor(mfma_f32_32x32x4bf16_1k op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x4bf16_1k : public ::mlir::Op<mfma_f32_32x32x4bf16_1k, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x4bf16_1kAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x4bf16.1k");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x4bf16_1k)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x4f16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x4f16Adaptor {
+public:
+  mfma_f32_32x32x4f16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x4f16Adaptor(mfma_f32_32x32x4f16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x4f16 : public ::mlir::Op<mfma_f32_32x32x4f16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x4f16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x4f16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x4f16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x8bf16_1k declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x8bf16_1kAdaptor {
+public:
+  mfma_f32_32x32x8bf16_1kAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x8bf16_1kAdaptor(mfma_f32_32x32x8bf16_1k op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x8bf16_1k : public ::mlir::Op<mfma_f32_32x32x8bf16_1k, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x8bf16_1kAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x8bf16.1k");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x8bf16_1k)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_32x32x8f16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_32x32x8f16Adaptor {
+public:
+  mfma_f32_32x32x8f16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_32x32x8f16Adaptor(mfma_f32_32x32x8f16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_32x32x8f16 : public ::mlir::Op<mfma_f32_32x32x8f16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_32x32x8f16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.32x32x8f16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_32x32x8f16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_4x4x1f32 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_4x4x1f32Adaptor {
+public:
+  mfma_f32_4x4x1f32Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_4x4x1f32Adaptor(mfma_f32_4x4x1f32 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_4x4x1f32 : public ::mlir::Op<mfma_f32_4x4x1f32, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_4x4x1f32Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.4x4x1f32");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_4x4x1f32)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_4x4x2bf16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_4x4x2bf16Adaptor {
+public:
+  mfma_f32_4x4x2bf16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_4x4x2bf16Adaptor(mfma_f32_4x4x2bf16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_4x4x2bf16 : public ::mlir::Op<mfma_f32_4x4x2bf16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_4x4x2bf16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.4x4x2bf16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_4x4x2bf16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_4x4x4bf16_1k declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_4x4x4bf16_1kAdaptor {
+public:
+  mfma_f32_4x4x4bf16_1kAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_4x4x4bf16_1kAdaptor(mfma_f32_4x4x4bf16_1k op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_4x4x4bf16_1k : public ::mlir::Op<mfma_f32_4x4x4bf16_1k, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_4x4x4bf16_1kAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.4x4x4bf16.1k");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_4x4x4bf16_1k)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f32_4x4x4f16 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f32_4x4x4f16Adaptor {
+public:
+  mfma_f32_4x4x4f16Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f32_4x4x4f16Adaptor(mfma_f32_4x4x4f16 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f32_4x4x4f16 : public ::mlir::Op<mfma_f32_4x4x4f16, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f32_4x4x4f16Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f32.4x4x4f16");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f32_4x4x4f16)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f64_16x16x4f64 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f64_16x16x4f64Adaptor {
+public:
+  mfma_f64_16x16x4f64Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f64_16x16x4f64Adaptor(mfma_f64_16x16x4f64 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f64_16x16x4f64 : public ::mlir::Op<mfma_f64_16x16x4f64, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f64_16x16x4f64Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f64.16x16x4f64");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f64_16x16x4f64)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_f64_4x4x4f64 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_f64_4x4x4f64Adaptor {
+public:
+  mfma_f64_4x4x4f64Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_f64_4x4x4f64Adaptor(mfma_f64_4x4x4f64 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_f64_4x4x4f64 : public ::mlir::Op<mfma_f64_4x4x4f64, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_f64_4x4x4f64Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.f64.4x4x4f64");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_f64_4x4x4f64)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_i32_16x16x16i8 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_i32_16x16x16i8Adaptor {
+public:
+  mfma_i32_16x16x16i8Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_i32_16x16x16i8Adaptor(mfma_i32_16x16x16i8 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_i32_16x16x16i8 : public ::mlir::Op<mfma_i32_16x16x16i8, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_i32_16x16x16i8Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.i32.16x16x16i8");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_i32_16x16x16i8)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_i32_16x16x32_i8 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_i32_16x16x32_i8Adaptor {
+public:
+  mfma_i32_16x16x32_i8Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_i32_16x16x32_i8Adaptor(mfma_i32_16x16x32_i8 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_i32_16x16x32_i8 : public ::mlir::Op<mfma_i32_16x16x32_i8, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_i32_16x16x32_i8Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.i32.16x16x32.i8");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_i32_16x16x32_i8)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_i32_16x16x4i8 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_i32_16x16x4i8Adaptor {
+public:
+  mfma_i32_16x16x4i8Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_i32_16x16x4i8Adaptor(mfma_i32_16x16x4i8 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_i32_16x16x4i8 : public ::mlir::Op<mfma_i32_16x16x4i8, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_i32_16x16x4i8Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.i32.16x16x4i8");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_i32_16x16x4i8)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_i32_32x32x16_i8 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_i32_32x32x16_i8Adaptor {
+public:
+  mfma_i32_32x32x16_i8Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_i32_32x32x16_i8Adaptor(mfma_i32_32x32x16_i8 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_i32_32x32x16_i8 : public ::mlir::Op<mfma_i32_32x32x16_i8, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_i32_32x32x16_i8Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.i32.32x32x16.i8");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_i32_32x32x16_i8)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_i32_32x32x4i8 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_i32_32x32x4i8Adaptor {
+public:
+  mfma_i32_32x32x4i8Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_i32_32x32x4i8Adaptor(mfma_i32_32x32x4i8 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_i32_32x32x4i8 : public ::mlir::Op<mfma_i32_32x32x4i8, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_i32_32x32x4i8Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.i32.32x32x4i8");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_i32_32x32x4i8)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_i32_32x32x8i8 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_i32_32x32x8i8Adaptor {
+public:
+  mfma_i32_32x32x8i8Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_i32_32x32x8i8Adaptor(mfma_i32_32x32x8i8 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_i32_32x32x8i8 : public ::mlir::Op<mfma_i32_32x32x8i8, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_i32_32x32x8i8Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.i32.32x32x8i8");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_i32_32x32x8i8)
+
+namespace mlir {
+namespace ROCDL {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ROCDL::mfma_i32_4x4x4i8 declarations
+//===----------------------------------------------------------------------===//
+
+class mfma_i32_4x4x4i8Adaptor {
+public:
+  mfma_i32_4x4x4i8Adaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  mfma_i32_4x4x4i8Adaptor(mfma_i32_4x4x4i8 op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getArgs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::llvm::Optional<::mlir::OperationName> odsOpName;
+};
+class mfma_i32_4x4x4i8 : public ::mlir::Op<mfma_i32_4x4x4i8, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::OneResult, ::mlir::OpTrait::OneTypedResult<::mlir::Type>::Impl, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = mfma_i32_4x4x4i8Adaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("rocdl.mfma.i32.4x4x4i8");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getArgs();
+  ::mlir::MutableOperandRange getArgsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Value getRes();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::Type res, ::mlir::ValueRange args);
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+public:
+};
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::mfma_i32_4x4x4i8)
+
+
+#endif  // GET_OP_CLASSES
+

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOpsDialect.h.inc
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOpsDialect.h.inc
@@ -1,0 +1,34 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Dialect Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+namespace ROCDL {
+
+class ROCDLDialect : public ::mlir::Dialect {
+  explicit ROCDLDialect(::mlir::MLIRContext *context);
+
+  void initialize();
+  friend class ::mlir::MLIRContext;
+public:
+  ~ROCDLDialect() override;
+  static constexpr ::llvm::StringLiteral getDialectNamespace() {
+    return ::llvm::StringLiteral("rocdl");
+  }
+
+    /// Provides a hook for verifying dialect attributes attached to the given
+    /// op.
+    ::mlir::LogicalResult verifyOperationAttribute(
+        ::mlir::Operation *op, ::mlir::NamedAttribute attribute) override;
+
+    /// Get the name of the attribute used to annotate external kernel
+    /// functions.
+    static StringRef getKernelFuncAttrName() { return "rocdl.kernel"; }
+  };
+} // namespace ROCDL
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ROCDL::ROCDLDialect)

--- a/mlir/include/mlir/IR/BuiltinAttributeInterfaces.h.inc
+++ b/mlir/include/mlir/IR/BuiltinAttributeInterfaces.h.inc
@@ -1,0 +1,554 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class ElementsAttr;
+namespace detail {
+struct ElementsAttrInterfaceTraits {
+  struct Concept {
+    ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> (*getValuesImpl)(const Concept *impl, ::mlir::Attribute , ::mlir::TypeID);
+    bool (*isSplat)(const Concept *impl, ::mlir::Attribute );
+    ::mlir::ShapedType (*getType)(const Concept *impl, ::mlir::Attribute );
+  };
+  template<typename ConcreteAttr>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::ElementsAttr;
+    Model() : Concept{getValuesImpl, isSplat, getType} {}
+
+    static inline ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> getValuesImpl(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID elementID);
+    static inline bool isSplat(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::ShapedType getType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+  };
+  template<typename ConcreteAttr>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::ElementsAttr;
+    FallbackModel() : Concept{getValuesImpl, isSplat, getType} {}
+
+    static inline ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> getValuesImpl(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID elementID);
+    static inline bool isSplat(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::ShapedType getType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+  };
+  template<typename ConcreteModel, typename ConcreteAttr>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteAttr;
+    ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> getValuesImpl(::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID elementID) const;
+    bool isSplat(::mlir::Attribute tablegen_opaque_val) const;
+  };
+};template <typename ConcreteAttr>
+struct ElementsAttrTrait;
+
+} // namespace detail
+class ElementsAttr : public ::mlir::AttributeInterface<ElementsAttr, detail::ElementsAttrInterfaceTraits> {
+public:
+  using ::mlir::AttributeInterface<ElementsAttr, detail::ElementsAttrInterfaceTraits>::AttributeInterface;
+  template <typename ConcreteAttr>
+  struct Trait : public detail::ElementsAttrTrait<ConcreteAttr> {};
+  /// This method returns an opaque range indexer for the given elementID, which
+  /// corresponds to a desired C++ element data type. Returns the indexer if the
+  /// attribute supports the given data type, failure otherwise.
+  ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> getValuesImpl(::mlir::TypeID elementID) const;
+  /// Returns true if the attribute elements correspond to a splat, i.e. that
+  /// all elements of the attribute are the same value.
+  bool isSplat() const;
+  /// Returns the shaped type of the elements attribute.
+  ::mlir::ShapedType getType() const;
+
+    template <typename T>
+    using iterator = detail::ElementsAttrIterator<T>;
+    template <typename T>
+    using iterator_range = detail::ElementsAttrRange<iterator<T>>;
+
+    //===------------------------------------------------------------------===//
+    // Accessors
+    //===------------------------------------------------------------------===//
+
+    /// Return the element type of this ElementsAttr.
+    Type getElementType() const { return getElementType(*this); }
+    static Type getElementType(ElementsAttr elementsAttr);
+
+    /// Return if the given 'index' refers to a valid element in this attribute.
+    bool isValidIndex(ArrayRef<uint64_t> index) const {
+      return isValidIndex(*this, index);
+    }
+    static bool isValidIndex(ShapedType type, ArrayRef<uint64_t> index);
+    static bool isValidIndex(ElementsAttr elementsAttr,
+                             ArrayRef<uint64_t> index);
+
+    /// Return the 1 dimensional flattened row-major index from the given
+    /// multi-dimensional index.
+    uint64_t getFlattenedIndex(ArrayRef<uint64_t> index) const {
+      return getFlattenedIndex(*this, index);
+    }
+    static uint64_t getFlattenedIndex(Type type,
+                                      ArrayRef<uint64_t> index);
+    static uint64_t getFlattenedIndex(ElementsAttr elementsAttr,
+                                      ArrayRef<uint64_t> index) {
+      return getFlattenedIndex(elementsAttr.getType(), index);
+    }
+
+    /// Returns the number of elements held by this attribute.
+    int64_t getNumElements() const { return getNumElements(*this); }
+    static int64_t getNumElements(ElementsAttr elementsAttr);
+
+    //===------------------------------------------------------------------===//
+    // Value Iteration
+    //===------------------------------------------------------------------===//
+
+    template <typename T>
+    using DerivedAttrValueCheckT =
+        std::enable_if_t<std::is_base_of<Attribute, T>::value &&
+                         !std::is_same<Attribute, T>::value>;
+    template <typename T, typename ResultT>
+    using DefaultValueCheckT =
+        std::enable_if_t<std::is_same<Attribute, T>::value ||
+                             !std::is_base_of<Attribute, T>::value,
+                         ResultT>;
+
+    /// Return the splat value for this attribute. This asserts that the
+    /// attribute corresponds to a splat.
+    template <typename T>
+    T getSplatValue() const {
+      assert(isSplat() && "expected splat attribute");
+      return *value_begin<T>();
+    }
+
+    /// Return the elements of this attribute as a value of type 'T'.
+    template <typename T>
+    DefaultValueCheckT<T, iterator_range<T>> getValues() const {
+      return {getType(), value_begin<T>(), value_end<T>()};
+    }
+    template <typename T>
+    DefaultValueCheckT<T, iterator<T>> value_begin() const;
+    template <typename T>
+    DefaultValueCheckT<T, iterator<T>> value_end() const {
+      return iterator<T>({}, size());
+    }
+
+    /// Return the held element values a range of T, where T is a derived
+    /// attribute type.
+    template <typename T>
+    using DerivedAttrValueIterator =
+      llvm::mapped_iterator<iterator<Attribute>, T (*)(Attribute)>;
+    template <typename T>
+    using DerivedAttrValueIteratorRange =
+      detail::ElementsAttrRange<DerivedAttrValueIterator<T>>;
+    template <typename T, typename = DerivedAttrValueCheckT<T>>
+    DerivedAttrValueIteratorRange<T> getValues() const {
+      auto castFn = [](Attribute attr) { return attr.template cast<T>(); };
+      return {getType(), llvm::map_range(getValues<Attribute>(),
+              static_cast<T (*)(Attribute)>(castFn))};
+    }
+    template <typename T, typename = DerivedAttrValueCheckT<T>>
+    DerivedAttrValueIterator<T> value_begin() const {
+      return getValues<T>().begin();
+    }
+    template <typename T, typename = DerivedAttrValueCheckT<T>>
+    DerivedAttrValueIterator<T> value_end() const {
+      return {value_end<Attribute>(), nullptr};
+    }
+
+    //===------------------------------------------------------------------===//
+    // Failable Value Iteration
+
+    /// If this attribute supports iterating over element values of type `T`,
+    /// return the iterable range. Otherwise, return std::nullopt.
+    template <typename T>
+    DefaultValueCheckT<T, Optional<iterator_range<T>>> tryGetValues() const {
+      if (Optional<iterator<T>> beginIt = try_value_begin<T>())
+        return iterator_range<T>(getType(), *beginIt, value_end<T>());
+      return std::nullopt;
+    }
+    template <typename T>
+    DefaultValueCheckT<T, Optional<iterator<T>>> try_value_begin() const;
+
+    /// If this attribute supports iterating over element values of type `T`,
+    /// return the iterable range. Otherwise, return std::nullopt.
+    template <typename T, typename = DerivedAttrValueCheckT<T>>
+    Optional<DerivedAttrValueIteratorRange<T>> tryGetValues() const {
+      auto values = tryGetValues<Attribute>();
+      if (!values)
+        return std::nullopt;
+
+      auto castFn = [](Attribute attr) { return attr.template cast<T>(); };
+      return DerivedAttrValueIteratorRange<T>(
+        getType(),
+        llvm::map_range(*values, static_cast<T (*)(Attribute)>(castFn))
+      );
+    }
+    template <typename T, typename = DerivedAttrValueCheckT<T>>
+    Optional<DerivedAttrValueIterator<T>> try_value_begin() const {
+      if (auto values = tryGetValues<T>())
+        return values->begin();
+      return std::nullopt;
+    }
+  
+    /// Return the number of elements held by this attribute.
+    int64_t size() const { return getNumElements(); }
+
+    /// Return if the attribute holds no elements.
+    bool empty() const { return size() == 0; }
+  
+};
+namespace detail {
+  template <typename ConcreteAttr>
+  struct ElementsAttrTrait : public ::mlir::AttributeInterface<ElementsAttr, detail::ElementsAttrInterfaceTraits>::Trait<ConcreteAttr> {
+    /// This method returns an opaque range indexer for the given elementID, which
+    /// corresponds to a desired C++ element data type. Returns the indexer if the
+    /// attribute supports the given data type, failure otherwise.
+    ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> getValuesImpl(::mlir::TypeID elementID) const {
+      auto result = getValueImpl(
+        (typename ConcreteAttr::ContiguousIterableTypesT *)nullptr, elementID,
+        /*isContiguous=*/std::true_type());
+      if (succeeded(result))
+        return std::move(result);
+
+      return getValueImpl(
+        (typename ConcreteAttr::NonContiguousIterableTypesT *)nullptr,
+        elementID, /*isContiguous=*/std::false_type());
+    }
+    /// Returns true if the attribute elements correspond to a splat, i.e. that
+    /// all elements of the attribute are the same value.
+    bool isSplat() const {
+      // By default, only check for a single element splat.
+        return (*static_cast<const ConcreteAttr *>(this)).getNumElements() == 1;
+    }
+
+    // By default, no types are iterable.
+    using ContiguousIterableTypesT = std::tuple<>;
+    using NonContiguousIterableTypesT = std::tuple<>;
+
+    //===------------------------------------------------------------------===//
+    // Accessors
+    //===------------------------------------------------------------------===//
+
+    /// Return the element type of this ElementsAttr.
+    Type getElementType() const {
+      return ::mlir::ElementsAttr::getElementType((*static_cast<const ConcreteAttr *>(this)));
+    }
+
+    /// Returns the number of elements held by this attribute.
+    int64_t getNumElements() const {
+      return ::mlir::ElementsAttr::getNumElements((*static_cast<const ConcreteAttr *>(this)));
+    }
+
+    /// Return if the given 'index' refers to a valid element in this attribute.
+    bool isValidIndex(ArrayRef<uint64_t> index) const {
+      return ::mlir::ElementsAttr::isValidIndex((*static_cast<const ConcreteAttr *>(this)), index);
+    }
+
+  protected:
+    /// Returns the 1-dimensional flattened row-major index from the given
+    /// multi-dimensional index.
+    uint64_t getFlattenedIndex(ArrayRef<uint64_t> index) const {
+      return ::mlir::ElementsAttr::getFlattenedIndex((*static_cast<const ConcreteAttr *>(this)), index);
+    }
+
+    //===------------------------------------------------------------------===//
+    // Value Iteration Internals
+    //===------------------------------------------------------------------===//
+  protected:
+    /// This class is used to allow specifying function overloads for different
+    /// types, without actually taking the types as parameters. This avoids the
+    /// need to build complicated SFINAE to select specific overloads.
+    template <typename T>
+    struct OverloadToken {};
+
+  private:
+    /// This function unpacks the types within a given tuple and then forwards
+    /// on to the unwrapped variant.
+    template <typename... Ts, typename IsContiguousT>
+    auto getValueImpl(std::tuple<Ts...> *, ::mlir::TypeID elementID,
+                      IsContiguousT isContiguous) const {
+      return getValueImpl<Ts...>(elementID, isContiguous);
+    }
+    /// Check to see if the given `elementID` matches the current type `T`. If
+    /// it does, build a value result using the current type. If it doesn't,
+    /// keep looking for the desired type.
+    template <typename T, typename... Ts, typename IsContiguousT>
+    auto getValueImpl(::mlir::TypeID elementID,
+                      IsContiguousT isContiguous) const {
+      if (::mlir::TypeID::get<T>() == elementID)
+        return buildValueResult<T>(isContiguous);
+      return getValueImpl<Ts...>(elementID, isContiguous);
+    }
+    /// Bottom out case for no matching type.
+    template <typename IsContiguousT>
+    ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer>
+    getValueImpl(::mlir::TypeID, IsContiguousT) const {
+      return failure();
+    }
+
+    /// Build an indexer for the given type `T`, which is represented via a
+    /// contiguous range.
+    template <typename T>
+    ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> buildValueResult(
+        /*isContiguous*/std::true_type) const {
+      if ((*static_cast<const ConcreteAttr *>(this)).empty()) {
+        return ::mlir::detail::ElementsAttrIndexer::contiguous<T>(
+          /*isSplat=*/false, nullptr);
+      }
+
+      auto valueIt = (*static_cast<const ConcreteAttr *>(this)).try_value_begin_impl(OverloadToken<T>());
+      if (::mlir::failed(valueIt))
+        return ::mlir::failure();
+      return ::mlir::detail::ElementsAttrIndexer::contiguous(
+        (*static_cast<const ConcreteAttr *>(this)).isSplat(), &**valueIt);
+    }
+    /// Build an indexer for the given type `T`, which is represented via a
+    /// non-contiguous range.
+    template <typename T>
+    ::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> buildValueResult(
+        /*isContiguous*/std::false_type) const {
+      auto valueIt = (*static_cast<const ConcreteAttr *>(this)).try_value_begin_impl(OverloadToken<T>());
+      if (::mlir::failed(valueIt))
+        return ::mlir::failure();
+      return ::mlir::detail::ElementsAttrIndexer::nonContiguous(
+        (*static_cast<const ConcreteAttr *>(this)).isSplat(), *valueIt);
+    }
+
+  public:
+    //===------------------------------------------------------------------===//
+    // Value Iteration
+    //===------------------------------------------------------------------===//
+
+    /// The iterator for the given element type T.
+    template <typename T, typename AttrT = ConcreteAttr>
+    using iterator = decltype(std::declval<AttrT>().template value_begin<T>());
+    /// The iterator range over the given element T.
+    template <typename T, typename AttrT = ConcreteAttr>
+    using iterator_range =
+        decltype(std::declval<AttrT>().template getValues<T>());
+
+    /// Return an iterator to the first element of this attribute as a value of
+    /// type `T`.
+    template <typename T>
+    auto value_begin() const {
+      return *(*static_cast<const ConcreteAttr *>(this)).try_value_begin_impl(OverloadToken<T>());
+    }
+
+    /// Return the elements of this attribute as a value of type 'T'.
+    template <typename T>
+    auto getValues() const {
+      auto beginIt = (*static_cast<const ConcreteAttr *>(this)).template value_begin<T>();
+      return detail::ElementsAttrRange<decltype(beginIt)>(
+        (*static_cast<const ConcreteAttr *>(this)).getType(), beginIt, std::next(beginIt, size()));
+    }
+  
+    /// Return the number of elements held by this attribute.
+    int64_t size() const { return getNumElements(); }
+
+    /// Return if the attribute holds no elements.
+    bool empty() const { return size() == 0; }
+  
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class MemRefLayoutAttrInterface;
+namespace detail {
+struct MemRefLayoutAttrInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::AffineMap (*getAffineMap)(const Concept *impl, ::mlir::Attribute );
+    bool (*isIdentity)(const Concept *impl, ::mlir::Attribute );
+    ::mlir::LogicalResult (*verifyLayout)(const Concept *impl, ::mlir::Attribute , ::llvm::ArrayRef<int64_t>, ::llvm::function_ref<::mlir::InFlightDiagnostic()>);
+  };
+  template<typename ConcreteAttr>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::MemRefLayoutAttrInterface;
+    Model() : Concept{getAffineMap, isIdentity, verifyLayout} {}
+
+    static inline ::mlir::AffineMap getAffineMap(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline bool isIdentity(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::LogicalResult verifyLayout(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError);
+  };
+  template<typename ConcreteAttr>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::MemRefLayoutAttrInterface;
+    FallbackModel() : Concept{getAffineMap, isIdentity, verifyLayout} {}
+
+    static inline ::mlir::AffineMap getAffineMap(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline bool isIdentity(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::LogicalResult verifyLayout(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError);
+  };
+  template<typename ConcreteModel, typename ConcreteAttr>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteAttr;
+    bool isIdentity(::mlir::Attribute tablegen_opaque_val) const;
+    ::mlir::LogicalResult verifyLayout(::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) const;
+  };
+};template <typename ConcreteAttr>
+struct MemRefLayoutAttrInterfaceTrait;
+
+} // namespace detail
+class MemRefLayoutAttrInterface : public ::mlir::AttributeInterface<MemRefLayoutAttrInterface, detail::MemRefLayoutAttrInterfaceInterfaceTraits> {
+public:
+  using ::mlir::AttributeInterface<MemRefLayoutAttrInterface, detail::MemRefLayoutAttrInterfaceInterfaceTraits>::AttributeInterface;
+  template <typename ConcreteAttr>
+  struct Trait : public detail::MemRefLayoutAttrInterfaceTrait<ConcreteAttr> {};
+  /// Get the MemRef layout as an AffineMap, the method must not return NULL
+  ::mlir::AffineMap getAffineMap() const;
+  /// Return true if this attribute represents the identity layout
+  bool isIdentity() const;
+  /// Check if the current layout is applicable to the provided shape
+  ::mlir::LogicalResult verifyLayout(::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) const;
+};
+namespace detail {
+  template <typename ConcreteAttr>
+  struct MemRefLayoutAttrInterfaceTrait : public ::mlir::AttributeInterface<MemRefLayoutAttrInterface, detail::MemRefLayoutAttrInterfaceInterfaceTraits>::Trait<ConcreteAttr> {
+    /// Return true if this attribute represents the identity layout
+    bool isIdentity() const {
+      return (*static_cast<const ConcreteAttr *>(this)).getAffineMap().isIdentity();
+    }
+    /// Check if the current layout is applicable to the provided shape
+    ::mlir::LogicalResult verifyLayout(::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) const {
+      return ::mlir::detail::verifyAffineMapAsLayout((*static_cast<const ConcreteAttr *>(this)).getAffineMap(),
+                                                       shape, emitError);
+    }
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class TypedAttr;
+namespace detail {
+struct TypedAttrInterfaceTraits {
+  struct Concept {
+    ::mlir::Type (*getType)(const Concept *impl, ::mlir::Attribute );
+  };
+  template<typename ConcreteAttr>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::TypedAttr;
+    Model() : Concept{getType} {}
+
+    static inline ::mlir::Type getType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+  };
+  template<typename ConcreteAttr>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::TypedAttr;
+    FallbackModel() : Concept{getType} {}
+
+    static inline ::mlir::Type getType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+  };
+  template<typename ConcreteModel, typename ConcreteAttr>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteAttr;
+  };
+};template <typename ConcreteAttr>
+struct TypedAttrTrait;
+
+} // namespace detail
+class TypedAttr : public ::mlir::AttributeInterface<TypedAttr, detail::TypedAttrInterfaceTraits> {
+public:
+  using ::mlir::AttributeInterface<TypedAttr, detail::TypedAttrInterfaceTraits>::AttributeInterface;
+  template <typename ConcreteAttr>
+  struct Trait : public detail::TypedAttrTrait<ConcreteAttr> {};
+  /// Get the attribute's type
+  ::mlir::Type getType() const;
+};
+namespace detail {
+  template <typename ConcreteAttr>
+  struct TypedAttrTrait : public ::mlir::AttributeInterface<TypedAttr, detail::TypedAttrInterfaceTraits>::Trait<ConcreteAttr> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteAttr>
+::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> detail::ElementsAttrInterfaceTraits::Model<ConcreteAttr>::getValuesImpl(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID elementID) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getValuesImpl(elementID);
+}
+template<typename ConcreteAttr>
+bool detail::ElementsAttrInterfaceTraits::Model<ConcreteAttr>::isSplat(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).isSplat();
+}
+template<typename ConcreteAttr>
+::mlir::ShapedType detail::ElementsAttrInterfaceTraits::Model<ConcreteAttr>::getType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getType();
+}
+template<typename ConcreteAttr>
+::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> detail::ElementsAttrInterfaceTraits::FallbackModel<ConcreteAttr>::getValuesImpl(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID elementID) {
+  return static_cast<const ConcreteAttr *>(impl)->getValuesImpl(tablegen_opaque_val, elementID);
+}
+template<typename ConcreteAttr>
+bool detail::ElementsAttrInterfaceTraits::FallbackModel<ConcreteAttr>::isSplat(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return static_cast<const ConcreteAttr *>(impl)->isSplat(tablegen_opaque_val);
+}
+template<typename ConcreteAttr>
+::mlir::ShapedType detail::ElementsAttrInterfaceTraits::FallbackModel<ConcreteAttr>::getType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return static_cast<const ConcreteAttr *>(impl)->getType(tablegen_opaque_val);
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+::mlir::FailureOr<::mlir::detail::ElementsAttrIndexer> detail::ElementsAttrInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::getValuesImpl(::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID elementID) const {
+auto result = getValueImpl(
+        (typename ConcreteAttr::ContiguousIterableTypesT *)nullptr, elementID,
+        /*isContiguous=*/std::true_type());
+      if (succeeded(result))
+        return std::move(result);
+
+      return getValueImpl(
+        (typename ConcreteAttr::NonContiguousIterableTypesT *)nullptr,
+        elementID, /*isContiguous=*/std::false_type());
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+bool detail::ElementsAttrInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::isSplat(::mlir::Attribute tablegen_opaque_val) const {
+// By default, only check for a single element splat.
+        return (tablegen_opaque_val.cast<ConcreteAttr>()).getNumElements() == 1;
+}
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteAttr>
+::mlir::AffineMap detail::MemRefLayoutAttrInterfaceInterfaceTraits::Model<ConcreteAttr>::getAffineMap(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getAffineMap();
+}
+template<typename ConcreteAttr>
+bool detail::MemRefLayoutAttrInterfaceInterfaceTraits::Model<ConcreteAttr>::isIdentity(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).isIdentity();
+}
+template<typename ConcreteAttr>
+::mlir::LogicalResult detail::MemRefLayoutAttrInterfaceInterfaceTraits::Model<ConcreteAttr>::verifyLayout(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).verifyLayout(shape, emitError);
+}
+template<typename ConcreteAttr>
+::mlir::AffineMap detail::MemRefLayoutAttrInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::getAffineMap(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return static_cast<const ConcreteAttr *>(impl)->getAffineMap(tablegen_opaque_val);
+}
+template<typename ConcreteAttr>
+bool detail::MemRefLayoutAttrInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::isIdentity(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return static_cast<const ConcreteAttr *>(impl)->isIdentity(tablegen_opaque_val);
+}
+template<typename ConcreteAttr>
+::mlir::LogicalResult detail::MemRefLayoutAttrInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::verifyLayout(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) {
+  return static_cast<const ConcreteAttr *>(impl)->verifyLayout(tablegen_opaque_val, shape, emitError);
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+bool detail::MemRefLayoutAttrInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::isIdentity(::mlir::Attribute tablegen_opaque_val) const {
+return (tablegen_opaque_val.cast<ConcreteAttr>()).getAffineMap().isIdentity();
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+::mlir::LogicalResult detail::MemRefLayoutAttrInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::verifyLayout(::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) const {
+return ::mlir::detail::verifyAffineMapAsLayout((tablegen_opaque_val.cast<ConcreteAttr>()).getAffineMap(),
+                                                       shape, emitError);
+}
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteAttr>
+::mlir::Type detail::TypedAttrInterfaceTraits::Model<ConcreteAttr>::getType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getType();
+}
+template<typename ConcreteAttr>
+::mlir::Type detail::TypedAttrInterfaceTraits::FallbackModel<ConcreteAttr>::getType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return static_cast<const ConcreteAttr *>(impl)->getType(tablegen_opaque_val);
+}
+} // namespace mlir

--- a/mlir/include/mlir/IR/BuiltinAttributes.h.inc
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h.inc
@@ -1,0 +1,671 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* AttrDef Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifdef GET_ATTRDEF_CLASSES
+#undef GET_ATTRDEF_CLASSES
+
+
+namespace mlir {
+class AsmParser;
+class AsmPrinter;
+} // namespace mlir
+namespace mlir {
+class AffineMapAttr;
+class ArrayAttr;
+class DenseArrayAttr;
+class DenseIntOrFPElementsAttr;
+class DenseResourceElementsAttr;
+class DenseStringElementsAttr;
+class DictionaryAttr;
+class FloatAttr;
+class IntegerAttr;
+class IntegerSetAttr;
+class OpaqueAttr;
+class SparseElementsAttr;
+class StringAttr;
+class SymbolRefAttr;
+class TypeAttr;
+class UnitAttr;
+class StridedLayoutAttr;
+namespace detail {
+struct AffineMapAttrStorage;
+} // namespace detail
+class AffineMapAttr : public ::mlir::Attribute::AttrBase<AffineMapAttr, ::mlir::Attribute, detail::AffineMapAttrStorage, ::mlir::MemRefLayoutAttrInterface::Trait> {
+public:
+  using Base::Base;
+  using ValueType = AffineMap;
+  AffineMap getAffineMap() const { return getValue(); }
+  static AffineMapAttr get(AffineMap value);
+  AffineMap getValue() const;
+};
+namespace detail {
+struct ArrayAttrStorage;
+} // namespace detail
+class ArrayAttr : public ::mlir::Attribute::AttrBase<ArrayAttr, ::mlir::Attribute, detail::ArrayAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+    using ValueType = ArrayRef<Attribute>;
+
+    /// Return the element at the given index.
+    Attribute operator[](unsigned idx) const {
+      assert(idx < size() && "index out of bounds");
+      return getValue()[idx];
+    }
+
+    /// Support range iteration.
+    using iterator = llvm::ArrayRef<Attribute>::iterator;
+    iterator begin() const { return getValue().begin(); }
+    iterator end() const { return getValue().end(); }
+    size_t size() const { return getValue().size(); }
+    bool empty() const { return size() == 0; }
+
+  private:
+    /// Class for underlying value iterator support.
+    template <typename AttrTy>
+    class attr_value_iterator final
+        : public llvm::mapped_iterator<ArrayAttr::iterator,
+                                       AttrTy (*)(Attribute)> {
+    public:
+      explicit attr_value_iterator(ArrayAttr::iterator it)
+          : llvm::mapped_iterator<ArrayAttr::iterator, AttrTy (*)(Attribute)>(
+                it, [](Attribute attr) { return attr.cast<AttrTy>(); }) {}
+      AttrTy operator*() const { return (*this->I).template cast<AttrTy>(); }
+    };
+
+  public:
+    template <typename AttrTy>
+    iterator_range<attr_value_iterator<AttrTy>> getAsRange() const {
+      return llvm::make_range(attr_value_iterator<AttrTy>(begin()),
+                              attr_value_iterator<AttrTy>(end()));
+    }
+    template <typename AttrTy,
+              typename UnderlyingTy = typename AttrTy::ValueType>
+    auto getAsValueRange() const {
+      return llvm::map_range(getAsRange<AttrTy>(), [](AttrTy attr) {
+        return static_cast<UnderlyingTy>(attr.getValue());
+      });
+    }
+  static ArrayAttr get(::mlir::MLIRContext *context, ::llvm::ArrayRef<Attribute> value);
+  ::llvm::ArrayRef<Attribute> getValue() const;
+};
+namespace detail {
+struct DenseArrayAttrStorage;
+} // namespace detail
+class DenseArrayAttr : public ::mlir::Attribute::AttrBase<DenseArrayAttr, ::mlir::Attribute, detail::DenseArrayAttrStorage> {
+public:
+  using Base::Base;
+  /// Get the number of elements in the array.
+  int64_t size() const { return getSize(); }
+  /// Return true if there are no elements in the dense array.
+  bool empty() const { return !size(); }
+  using Base::getChecked;
+  static DenseArrayAttr get(::mlir::MLIRContext *context, Type elementType, int64_t size, ::llvm::ArrayRef<char> rawData);
+  static DenseArrayAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, Type elementType, int64_t size, ::llvm::ArrayRef<char> rawData);
+  static DenseArrayAttr get(Type elementType, unsigned size, ArrayRef<char> rawData);
+  static DenseArrayAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned size, ArrayRef<char> rawData);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, int64_t size, ::llvm::ArrayRef<char> rawData);
+  Type getElementType() const;
+  int64_t getSize() const;
+  ::llvm::ArrayRef<char> getRawData() const;
+};
+namespace detail {
+struct DenseIntOrFPElementsAttrStorage;
+} // namespace detail
+class DenseIntOrFPElementsAttr : public ::mlir::Attribute::AttrBase<DenseIntOrFPElementsAttr, DenseElementsAttr, detail::DenseIntOrFPElementsAttrStorage, ::mlir::ElementsAttr::Trait, ::mlir::TypedAttr::Trait> {
+public:
+  using Base::Base;
+    using DenseElementsAttr::empty;
+    using DenseElementsAttr::getNumElements;
+    using DenseElementsAttr::getElementType;
+    using DenseElementsAttr::getValues;
+    using DenseElementsAttr::isSplat;
+    using DenseElementsAttr::size;
+    using DenseElementsAttr::value_begin;
+
+    /// The set of data types that can be iterated by this attribute.
+    using ContiguousIterableTypesT = std::tuple<
+      // Integer types.
+      uint8_t, uint16_t, uint32_t, uint64_t,
+      int8_t, int16_t, int32_t, int64_t,
+      short, unsigned short, int, unsigned, long, unsigned long,
+      std::complex<uint8_t>, std::complex<uint16_t>, std::complex<uint32_t>,
+      std::complex<uint64_t>,
+      std::complex<int8_t>, std::complex<int16_t>, std::complex<int32_t>,
+      std::complex<int64_t>,
+      // Float types.
+      float, double, std::complex<float>, std::complex<double>
+    >;
+    using NonContiguousIterableTypesT = std::tuple<
+      Attribute,
+      // Integer types.
+      APInt, bool, std::complex<APInt>,
+      // Float types.
+      APFloat, std::complex<APFloat>
+    >;
+
+    /// Provide a `try_value_begin_impl` to enable iteration within
+    /// ElementsAttr.
+    template <typename T>
+    auto try_value_begin_impl(OverloadToken<T>) const {
+      return try_value_begin<T>();
+    }
+
+    /// Convert endianess of input ArrayRef for big-endian(BE) machines. All of
+    /// the elements of `inRawData` has `type`. If `inRawData` is little endian
+    /// (LE), it is converted to big endian (BE). Conversely, if `inRawData` is
+    /// BE, converted to LE.
+    static void
+    convertEndianOfArrayRefForBEmachine(ArrayRef<char> inRawData,
+                                        MutableArrayRef<char> outRawData,
+                                        ShapedType type);
+
+    /// Convert endianess of input for big-endian(BE) machines. The number of
+    /// elements of `inRawData` is `numElements`, and each element has
+    /// `elementBitWidth` bits. If `inRawData` is little endian (LE), it is
+    /// converted to big endian (BE) and saved in `outRawData`. Conversely, if
+    /// `inRawData` is BE, converted to LE.
+    static void convertEndianOfCharForBEmachine(const char *inRawData,
+                                                char *outRawData,
+                                                size_t elementBitWidth,
+                                                size_t numElements);
+
+  protected:
+    friend DenseElementsAttr;
+
+    /// Constructs a dense elements attribute from an array of raw APFloat
+    /// values. Each APFloat value is expected to have the same bitwidth as the
+    /// element type of 'type'. 'type' must be a vector or tensor with static
+    /// shape.
+    ///
+    /// If the `values` array only has a single element, then this constructs
+    /// splat of that value.
+    static DenseElementsAttr getRaw(ShapedType type, size_t storageWidth,
+                                    ArrayRef<APFloat> values);
+
+    /// Constructs a dense elements attribute from an array of raw APInt values.
+    /// Each APInt value is expected to have the same bitwidth as the element
+    /// type of 'type'. 'type' must be a vector or tensor with static shape.
+    ///
+    /// If the `values` array only has a single element, then this constructs
+    /// splat of that value.
+    static DenseElementsAttr getRaw(ShapedType type, size_t storageWidth,
+                                    ArrayRef<APInt> values);
+
+    /// Get or create a new dense elements attribute instance with the given raw
+    /// data buffer. 'type' must be a vector or tensor with static shape.
+    ///
+    /// If the `values` array only has a single element, then this constructs
+    /// splat of that value.
+    static DenseElementsAttr getRaw(ShapedType type, ArrayRef<char> data);
+
+    /// Overload of the raw 'get' method that asserts that the given type is of
+    /// complex type. This method is used to verify type invariants that the
+    /// templatized 'get' method cannot.
+    static DenseElementsAttr getRawComplex(ShapedType type, ArrayRef<char> data,
+                                           int64_t dataEltSize, bool isInt,
+                                           bool isSigned);
+
+    /// Overload of the raw 'get' method that asserts that the given type is of
+    /// integer or floating-point type. This method is used to verify type
+    /// invariants that the templatized 'get' method cannot.
+    static DenseElementsAttr getRawIntOrFloat(ShapedType type,
+                                              ArrayRef<char> data,
+                                              int64_t dataEltSize, bool isInt,
+                                              bool isSigned);
+  public:
+};
+namespace detail {
+struct DenseResourceElementsAttrStorage;
+} // namespace detail
+class DenseResourceElementsAttr : public ::mlir::Attribute::AttrBase<DenseResourceElementsAttr, ::mlir::Attribute, detail::DenseResourceElementsAttrStorage, ::mlir::ElementsAttr::Trait, ::mlir::TypedAttr::Trait> {
+public:
+  using Base::Base;
+  protected:
+    /// A builder that inserts a new resource into the builtin dialect's blob
+    /// manager using the provided blob. The handle of the inserted blob is used
+    /// when building the attribute. The provided `blobName` is used as a hint
+    /// for the key of the new handle for the `blob` resource, but may be
+    /// changed if necessary to ensure uniqueness during insertion.
+    static DenseResourceElementsAttr get(
+      ShapedType type, StringRef blobName, AsmResourceBlob blob
+    );
+
+  public:
+  static DenseResourceElementsAttr get(ShapedType type, DenseResourceElementsHandle handle);
+  ShapedType getType() const;
+  DenseResourceElementsHandle getRawHandle() const;
+};
+namespace detail {
+struct DenseStringElementsAttrStorage;
+} // namespace detail
+class DenseStringElementsAttr : public ::mlir::Attribute::AttrBase<DenseStringElementsAttr, DenseElementsAttr, detail::DenseStringElementsAttrStorage, ::mlir::ElementsAttr::Trait, ::mlir::TypedAttr::Trait> {
+public:
+  using Base::Base;
+    using DenseElementsAttr::empty;
+    using DenseElementsAttr::getNumElements;
+    using DenseElementsAttr::getElementType;
+    using DenseElementsAttr::getValues;
+    using DenseElementsAttr::isSplat;
+    using DenseElementsAttr::size;
+    using DenseElementsAttr::value_begin;
+
+    /// The set of data types that can be iterated by this attribute.
+    using ContiguousIterableTypesT = std::tuple<StringRef>;
+    using NonContiguousIterableTypesT = std::tuple<Attribute>;
+
+    /// Provide a `try_value_begin_impl` to enable iteration within
+    /// ElementsAttr.
+    template <typename T>
+    auto try_value_begin_impl(OverloadToken<T>) const {
+      return try_value_begin<T>();
+    }
+
+  protected:
+    friend DenseElementsAttr;
+
+  public:
+  static DenseStringElementsAttr get(ShapedType type, ArrayRef<StringRef> values);
+};
+namespace detail {
+struct DictionaryAttrStorage;
+} // namespace detail
+class DictionaryAttr : public ::mlir::Attribute::AttrBase<DictionaryAttr, ::mlir::Attribute, detail::DictionaryAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+    using ValueType = ArrayRef<NamedAttribute>;
+
+    /// Construct a dictionary with an array of values that is known to already
+    /// be sorted by name and uniqued.
+    static DictionaryAttr getWithSorted(MLIRContext *context,
+                                        ArrayRef<NamedAttribute> value);
+
+    /// Return the specified attribute if present, null otherwise.
+    Attribute get(StringRef name) const;
+    Attribute get(StringAttr name) const;
+
+    /// Return the specified named attribute if present, std::nullopt otherwise.
+    Optional<NamedAttribute> getNamed(StringRef name) const;
+    Optional<NamedAttribute> getNamed(StringAttr name) const;
+
+    /// Return whether the specified attribute is present.
+    bool contains(StringRef name) const;
+    bool contains(StringAttr name) const;
+
+    /// Support range iteration.
+    using iterator = llvm::ArrayRef<NamedAttribute>::iterator;
+    iterator begin() const;
+    iterator end() const;
+    bool empty() const { return size() == 0; }
+    size_t size() const;
+
+    /// Sorts the NamedAttributes in the array ordered by name as expected by
+    /// getWithSorted and returns whether the values were sorted.
+    /// Requires: uniquely named attributes.
+    static bool sort(ArrayRef<NamedAttribute> values,
+                     SmallVectorImpl<NamedAttribute> &storage);
+
+    /// Sorts the NamedAttributes in the array ordered by name as expected by
+    /// getWithSorted in place on an array and returns whether the values needed
+    /// to be sorted.
+    /// Requires: uniquely named attributes.
+    static bool sortInPlace(SmallVectorImpl<NamedAttribute> &array);
+
+    /// Returns an entry with a duplicate name in `array`, if it exists, else
+    /// returns std::nullopt. If `isSorted` is true, the array is assumed to be
+    /// sorted else it will be sorted in place before finding the duplicate entry.
+    static Optional<NamedAttribute>
+    findDuplicate(SmallVectorImpl<NamedAttribute> &array, bool isSorted);
+
+    /// Return the specified attribute if present and is an instance of
+    /// `AttrClass`, null otherwise.
+    template<typename AttrClass, typename NameClass>
+    AttrClass getAs(NameClass &&name) const {
+      return get(std::forward<NameClass>(name))
+        .template dyn_cast_or_null<AttrClass>();
+    }
+
+  private:
+    /// Return empty dictionary.
+    static DictionaryAttr getEmpty(MLIRContext *context);
+
+    /// Return empty dictionary. This is a special variant of the above method
+    /// that is used by the MLIRContext to cache the empty dictionary instance.
+    static DictionaryAttr getEmptyUnchecked(MLIRContext *context);
+
+    /// Allow access to `getEmptyUnchecked`.
+    friend MLIRContext;
+
+  public:
+  static DictionaryAttr get(::mlir::MLIRContext *context, ArrayRef<NamedAttribute> value = std::nullopt);
+  ::llvm::ArrayRef<NamedAttribute> getValue() const;
+};
+namespace detail {
+struct FloatAttrStorage;
+} // namespace detail
+class FloatAttr : public ::mlir::Attribute::AttrBase<FloatAttr, ::mlir::Attribute, detail::FloatAttrStorage, ::mlir::TypedAttr::Trait> {
+public:
+  using Base::Base;
+  using ValueType = APFloat;
+
+  /// This function is used to convert the value to a double, even if it loses
+  /// precision.
+  double getValueAsDouble() const;
+  static double getValueAsDouble(APFloat val);
+  using Base::getChecked;
+  static FloatAttr get(Type type, const APFloat &value);
+  static FloatAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type type, const APFloat &value);
+  static FloatAttr get(Type type, double value);
+  static FloatAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type type, double value);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::Type type, ::llvm::APFloat value);
+  ::mlir::Type getType() const;
+  ::llvm::APFloat getValue() const;
+};
+namespace detail {
+struct IntegerAttrStorage;
+} // namespace detail
+class IntegerAttr : public ::mlir::Attribute::AttrBase<IntegerAttr, ::mlir::Attribute, detail::IntegerAttrStorage, ::mlir::TypedAttr::Trait> {
+public:
+  using Base::Base;
+    using ValueType = APInt;
+
+    /// Return the integer value as a 64-bit int. The attribute must be a
+    /// signless integer.
+    // TODO: Change callers to use getValue instead.
+    int64_t getInt() const;
+    /// Return the integer value as a signed 64-bit int. The attribute must be
+    /// a signed integer.
+    int64_t getSInt() const;
+    /// Return the integer value as a unsigned 64-bit int. The attribute must be
+    /// an unsigned integer.
+    uint64_t getUInt() const;
+
+    /// Return the value as an APSInt which carries the signed from the type of
+    /// the attribute.  This traps on signless integers types!
+    APSInt getAPSInt() const;
+
+  private:
+    /// Return a boolean attribute. This is a special variant of the `get`
+    /// method that is used by the MLIRContext to cache the boolean IntegerAttr
+    /// instances.
+    static BoolAttr getBoolAttrUnchecked(IntegerType type, bool value);
+
+    /// Allow access to `getBoolAttrUnchecked`.
+    friend MLIRContext;
+
+  public:
+  using Base::getChecked;
+  static IntegerAttr get(Type type, const APInt &value);
+  static IntegerAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type type, const APInt &value);
+  static IntegerAttr get(::mlir::MLIRContext *context, const APSInt &value);
+  static IntegerAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, const APSInt &value);
+  static IntegerAttr get(Type type, int64_t value);
+  static IntegerAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type type, int64_t value);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::Type type, APInt value);
+  ::mlir::Type getType() const;
+  APInt getValue() const;
+};
+namespace detail {
+struct IntegerSetAttrStorage;
+} // namespace detail
+class IntegerSetAttr : public ::mlir::Attribute::AttrBase<IntegerSetAttr, ::mlir::Attribute, detail::IntegerSetAttrStorage> {
+public:
+  using Base::Base;
+  using ValueType = IntegerSet;static IntegerSetAttr get(IntegerSet value);
+  IntegerSet getValue() const;
+};
+namespace detail {
+struct OpaqueAttrStorage;
+} // namespace detail
+class OpaqueAttr : public ::mlir::Attribute::AttrBase<OpaqueAttr, ::mlir::Attribute, detail::OpaqueAttrStorage, ::mlir::TypedAttr::Trait> {
+public:
+  using Base::Base;
+  using Base::getChecked;
+  static OpaqueAttr get(StringAttr dialect, StringRef attrData, Type type);
+  static OpaqueAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, StringAttr dialect, StringRef attrData, Type type);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, StringAttr dialectNamespace, ::llvm::StringRef attrData, ::mlir::Type type);
+  StringAttr getDialectNamespace() const;
+  ::llvm::StringRef getAttrData() const;
+  ::mlir::Type getType() const;
+};
+namespace detail {
+struct SparseElementsAttrStorage;
+} // namespace detail
+class SparseElementsAttr : public ::mlir::Attribute::AttrBase<SparseElementsAttr, ::mlir::Attribute, detail::SparseElementsAttrStorage, ::mlir::ElementsAttr::Trait, ::mlir::TypedAttr::Trait> {
+public:
+  using Base::Base;
+    /// The set of data types that can be iterated by this attribute.
+    // FIXME: Realistically, SparseElementsAttr could use ElementsAttr for the
+    // value storage. This would mean dispatching to `values` when accessing
+    // values. For now, we just add the types that can be iterated by
+    // DenseElementsAttr.
+    using NonContiguousIterableTypesT = std::tuple<
+      Attribute,
+      // Integer types.
+      APInt, bool, uint8_t, uint16_t, uint32_t, uint64_t,
+      int8_t, int16_t, int32_t, int64_t,
+      short, unsigned short, int, unsigned, long, unsigned long,
+      std::complex<APInt>, std::complex<uint8_t>, std::complex<uint16_t>,
+      std::complex<uint32_t>, std::complex<uint64_t>, std::complex<int8_t>,
+      std::complex<int16_t>, std::complex<int32_t>, std::complex<int64_t>,
+      // Float types.
+      APFloat, float, double,
+      std::complex<APFloat>, std::complex<float>, std::complex<double>,
+      // String types.
+      StringRef
+    >;
+    using ElementsAttr::Trait<SparseElementsAttr>::getValues;
+    using ElementsAttr::Trait<SparseElementsAttr>::value_begin;
+
+    template <typename T>
+    using iterator =
+        llvm::mapped_iterator<typename decltype(llvm::seq<ptrdiff_t>(0, 0))::iterator,
+                              std::function<T(ptrdiff_t)>>;
+
+    /// Provide a `try_value_begin_impl` to enable iteration within
+    /// ElementsAttr.
+    template <typename T>
+    FailureOr<iterator<T>> try_value_begin_impl(OverloadToken<T>) const;
+
+  private:
+    /// Get a zero APFloat for the given sparse attribute.
+    APFloat getZeroAPFloat() const;
+
+    /// Get a zero APInt for the given sparse attribute.
+    APInt getZeroAPInt() const;
+
+    /// Get a zero attribute for the given sparse attribute.
+    Attribute getZeroAttr() const;
+
+    /// Utility methods to generate a zero value of some type 'T'. This is used
+    /// by the 'iterator' class.
+    /// Get a zero for a given attribute type.
+    template <typename T>
+    std::enable_if_t<std::is_base_of<Attribute, T>::value, T>
+    getZeroValue() const {
+      return getZeroAttr().template cast<T>();
+    }
+    /// Get a zero for an APInt.
+    template <typename T>
+    std::enable_if_t<std::is_same<APInt, T>::value, T>
+    getZeroValue() const {
+      return getZeroAPInt();
+    }
+    template <typename T>
+    std::enable_if_t<std::is_same<std::complex<APInt>, T>::value, T>
+    getZeroValue() const {
+      APInt intZero = getZeroAPInt();
+      return {intZero, intZero};
+    }
+    /// Get a zero for an APFloat.
+    template <typename T>
+    std::enable_if_t<std::is_same<APFloat, T>::value, T>
+    getZeroValue() const {
+      return getZeroAPFloat();
+    }
+    template <typename T>
+    std::enable_if_t<std::is_same<std::complex<APFloat>, T>::value, T>
+    getZeroValue() const {
+      APFloat floatZero = getZeroAPFloat();
+      return {floatZero, floatZero};
+    }
+
+    /// Get a zero for an C++ integer, float, StringRef, or complex type.
+    template <typename T>
+    std::enable_if_t<std::numeric_limits<T>::is_integer ||
+                         DenseElementsAttr::is_valid_cpp_fp_type<T>::value ||
+                         std::is_same<T, StringRef>::value ||
+                         (detail::is_complex_t<T>::value &&
+                          !llvm::is_one_of<T, std::complex<APInt>,
+                                           std::complex<APFloat>>::value),
+                     T>
+    getZeroValue() const {
+      return T();
+    }
+
+    /// Flatten, and return, all of the sparse indices in this attribute in
+    /// row-major order.
+    std::vector<ptrdiff_t> getFlattenedSparseIndices() const;
+
+  public:
+  using Base::getChecked;
+  static SparseElementsAttr get(ShapedType type, DenseElementsAttr indices, DenseElementsAttr values);
+  static SparseElementsAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ShapedType type, DenseElementsAttr indices, DenseElementsAttr values);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ShapedType type, DenseIntElementsAttr indices, DenseElementsAttr values);
+  ShapedType getType() const;
+  DenseIntElementsAttr getIndices() const;
+  DenseElementsAttr getValues() const;
+};
+namespace detail {
+struct StringAttrStorage;
+} // namespace detail
+class StringAttr : public ::mlir::Attribute::AttrBase<StringAttr, ::mlir::Attribute, detail::StringAttrStorage, ::mlir::TypedAttr::Trait> {
+public:
+  using Base::Base;
+    using ValueType = StringRef;
+
+    /// If the value of this string is prefixed with a dialect namespace,
+    /// returns the dialect corresponding to that namespace if it is loaded,
+    /// nullptr otherwise. For example, the string `llvm.fastmathflags` would
+    /// return the LLVM dialect, assuming it is loaded in the context.
+    Dialect *getReferencedDialect() const;
+
+    /// Enable conversion to StringRef.
+    operator StringRef() const { return getValue(); }
+
+    /// Returns the underlying string value
+    StringRef strref() const { return getValue(); }
+
+    /// Convert the underling value to an std::string.
+    std::string str() const { return getValue().str(); }
+
+    /// Return a pointer to the start of the string data.
+    const char *data() const { return getValue().data(); }
+
+    /// Return the number of bytes in this string.
+    size_t size() const { return getValue().size(); }
+
+    /// Iterate over the underlying string data.
+    StringRef::iterator begin() const { return getValue().begin(); }
+    StringRef::iterator end() const { return getValue().end(); }
+
+    /// Compare the underlying string value to the one in `rhs`.
+    int compare(StringAttr rhs) const {
+      if (*this == rhs)
+        return 0;
+      return getValue().compare(rhs.getValue());
+    }
+
+  private:
+    /// Return an empty StringAttr with NoneType type. This is a special variant
+    /// of the `get` method that is used by the MLIRContext to cache the
+    /// instance.
+    static StringAttr getEmptyStringAttrUnchecked(MLIRContext *context);
+    friend MLIRContext;
+  public:
+  static StringAttr get(const Twine &bytes, Type type);
+  static StringAttr get(::mlir::MLIRContext *context, const Twine &bytes);
+  static StringAttr get(::mlir::MLIRContext *context);
+  ::llvm::StringRef getValue() const;
+  ::mlir::Type getType() const;
+};
+namespace detail {
+struct SymbolRefAttrStorage;
+} // namespace detail
+class SymbolRefAttr : public ::mlir::Attribute::AttrBase<SymbolRefAttr, ::mlir::Attribute, detail::SymbolRefAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static SymbolRefAttr get(MLIRContext *ctx, StringRef value,
+                           ArrayRef<FlatSymbolRefAttr> nestedRefs);
+  /// Convenience getters for building a SymbolRefAttr with no path, which is
+  /// known to produce a FlatSymbolRefAttr.
+  static FlatSymbolRefAttr get(StringAttr value);
+  static FlatSymbolRefAttr get(MLIRContext *ctx, StringRef value);
+
+  /// Convenience getter for buliding a SymbolRefAttr based on an operation
+  /// that implements the SymbolTrait.
+  static FlatSymbolRefAttr get(Operation *symbol);
+
+  /// Returns the name of the fully resolved symbol, i.e. the leaf of the
+  /// reference path.
+  StringAttr getLeafReference() const;
+  static SymbolRefAttr get(StringAttr rootReference, ArrayRef<FlatSymbolRefAttr> nestedReferences);
+  StringAttr getRootReference() const;
+  ::llvm::ArrayRef<FlatSymbolRefAttr> getNestedReferences() const;
+};
+namespace detail {
+struct TypeAttrStorage;
+} // namespace detail
+class TypeAttr : public ::mlir::Attribute::AttrBase<TypeAttr, ::mlir::Attribute, detail::TypeAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  using ValueType = Type;static TypeAttr get(Type type);
+  Type getValue() const;
+};
+class UnitAttr : public ::mlir::Attribute::AttrBase<UnitAttr, ::mlir::Attribute, ::mlir::AttributeStorage> {
+public:
+  using Base::Base;
+  static UnitAttr get(MLIRContext *context);
+};
+namespace detail {
+struct StridedLayoutAttrStorage;
+} // namespace detail
+class StridedLayoutAttr : public ::mlir::Attribute::AttrBase<StridedLayoutAttr, ::mlir::Attribute, detail::StridedLayoutAttrStorage, ::mlir::MemRefLayoutAttrInterface::Trait> {
+public:
+  using Base::Base;
+  /// Print the attribute to the given output stream.
+  void print(raw_ostream &os) const;
+  using Base::getChecked;
+  static StridedLayoutAttr get(::mlir::MLIRContext *context, int64_t offset, ::llvm::ArrayRef<int64_t> strides);
+  static StridedLayoutAttr getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, int64_t offset, ::llvm::ArrayRef<int64_t> strides);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, int64_t offset, ::llvm::ArrayRef<int64_t> strides);
+  int64_t getOffset() const;
+  ::llvm::ArrayRef<int64_t> getStrides() const;
+  ::mlir::AffineMap getAffineMap() const;
+  ::mlir::LogicalResult verifyLayout(::llvm::ArrayRef<int64_t> shape, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) const;
+};
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::AffineMapAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ArrayAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::DenseArrayAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::DenseIntOrFPElementsAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::DenseResourceElementsAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::DenseStringElementsAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::DictionaryAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::FloatAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::IntegerAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::IntegerSetAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::OpaqueAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::SparseElementsAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::StringAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::SymbolRefAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::TypeAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::UnitAttr)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::StridedLayoutAttr)
+
+#endif  // GET_ATTRDEF_CLASSES
+

--- a/mlir/include/mlir/IR/BuiltinDialect.h.inc
+++ b/mlir/include/mlir/IR/BuiltinDialect.h.inc
@@ -1,0 +1,33 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Dialect Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+
+class BuiltinDialect : public ::mlir::Dialect {
+  explicit BuiltinDialect(::mlir::MLIRContext *context);
+
+  void initialize();
+  friend class ::mlir::MLIRContext;
+public:
+  ~BuiltinDialect() override;
+  static constexpr ::llvm::StringLiteral getDialectNamespace() {
+    return ::llvm::StringLiteral("builtin");
+  }
+
+  private:
+    // Register the builtin Attributes.
+    void registerAttributes();
+    // Register the builtin Location Attributes.
+    void registerLocationAttributes();
+    // Register the builtin Types.
+    void registerTypes();
+
+  public:
+  };
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::BuiltinDialect)

--- a/mlir/include/mlir/IR/BuiltinLocationAttributes.h.inc
+++ b/mlir/include/mlir/IR/BuiltinLocationAttributes.h.inc
@@ -1,0 +1,135 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* AttrDef Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifdef GET_ATTRDEF_CLASSES
+#undef GET_ATTRDEF_CLASSES
+
+
+namespace mlir {
+class AsmParser;
+class AsmPrinter;
+} // namespace mlir
+namespace mlir {
+class CallSiteLoc;
+class FileLineColLoc;
+class FusedLoc;
+class NameLoc;
+class OpaqueLoc;
+class UnknownLoc;
+namespace detail {
+struct CallSiteLocAttrStorage;
+} // namespace detail
+class CallSiteLoc : public ::mlir::Attribute::AttrBase<CallSiteLoc, ::mlir::LocationAttr, detail::CallSiteLocAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static CallSiteLoc get(Location callee, Location caller);
+  static CallSiteLoc get(Location name, ArrayRef<Location> frames);
+  Location getCallee() const;
+  Location getCaller() const;
+};
+namespace detail {
+struct FileLineColLocAttrStorage;
+} // namespace detail
+class FileLineColLoc : public ::mlir::Attribute::AttrBase<FileLineColLoc, ::mlir::LocationAttr, detail::FileLineColLocAttrStorage> {
+public:
+  using Base::Base;
+  static FileLineColLoc get(StringAttr filename, unsigned line, unsigned column);
+  static FileLineColLoc get(::mlir::MLIRContext *context, StringRef filename, unsigned line, unsigned column);
+  StringAttr getFilename() const;
+  unsigned getLine() const;
+  unsigned getColumn() const;
+};
+namespace detail {
+struct FusedLocAttrStorage;
+} // namespace detail
+class FusedLoc : public ::mlir::Attribute::AttrBase<FusedLoc, ::mlir::LocationAttr, detail::FusedLocAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static Location get(ArrayRef<Location> locs, Attribute metadata,
+                      MLIRContext *context);
+  static Location get(MLIRContext *context, ArrayRef<Location> locs) {
+    return get(locs, Attribute(), context);
+  }
+  static FusedLoc get(::mlir::MLIRContext *context, ::llvm::ArrayRef<Location> locations, Attribute metadata);
+  ::llvm::ArrayRef<Location> getLocations() const;
+  Attribute getMetadata() const;
+};
+namespace detail {
+struct NameLocAttrStorage;
+} // namespace detail
+class NameLoc : public ::mlir::Attribute::AttrBase<NameLoc, ::mlir::LocationAttr, detail::NameLocAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  static NameLoc get(StringAttr name, Location childLoc);
+  static NameLoc get(StringAttr name);
+  StringAttr getName() const;
+  Location getChildLoc() const;
+};
+namespace detail {
+struct OpaqueLocAttrStorage;
+} // namespace detail
+class OpaqueLoc : public ::mlir::Attribute::AttrBase<OpaqueLoc, ::mlir::LocationAttr, detail::OpaqueLocAttrStorage, ::mlir::SubElementAttrInterface::Trait> {
+public:
+  using Base::Base;
+  /// Returns an instance of opaque location which contains a given pointer to
+  /// an object. The corresponding MLIR location is set to UnknownLoc.
+  template <typename T>
+  static OpaqueLoc get(T underlyingLocation, MLIRContext *context);
+
+  /// Returns an instance of opaque location which contains a given pointer to
+  /// an object and an additional MLIR location.
+  template <typename T>
+  static OpaqueLoc get(T underlyingLocation, Location fallbackLocation) {
+    return get(reinterpret_cast<uintptr_t>(underlyingLocation),
+               TypeID::get<T>(), fallbackLocation);
+  }
+
+  /// Returns a pointer to some data structure that opaque location stores.
+  template <typename T> static T getUnderlyingLocation(Location location) {
+    assert(isa<T>(location));
+    return reinterpret_cast<T>(
+        location.cast<mlir::OpaqueLoc>().getUnderlyingLocation());
+  }
+
+  /// Returns a pointer to some data structure that opaque location stores.
+  /// Returns nullptr if provided location is not opaque location or if it
+  /// contains a pointer of different type.
+  template <typename T>
+  static T getUnderlyingLocationOrNull(Location location) {
+    return isa<T>(location)
+               ? reinterpret_cast<T>(
+                     location.cast<mlir::OpaqueLoc>().getUnderlyingLocation())
+               : T(nullptr);
+  }
+
+  /// Checks whether provided location is opaque location and contains a
+  /// pointer to an object of particular type.
+  template <typename T> static bool isa(Location location) {
+    auto opaque_loc = location.dyn_cast<OpaqueLoc>();
+    return opaque_loc && opaque_loc.getUnderlyingTypeID() == TypeID::get<T>();
+  }
+  static OpaqueLoc get(uintptr_t underlyingLocation, TypeID underlyingTypeID, Location fallbackLocation);
+  uintptr_t getUnderlyingLocation() const;
+  TypeID getUnderlyingTypeID() const;
+  Location getFallbackLocation() const;
+};
+class UnknownLoc : public ::mlir::Attribute::AttrBase<UnknownLoc, ::mlir::LocationAttr, ::mlir::AttributeStorage> {
+public:
+  using Base::Base;
+  static UnknownLoc get(MLIRContext *context);
+};
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::CallSiteLoc)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::FileLineColLoc)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::FusedLoc)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NameLoc)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::OpaqueLoc)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::UnknownLoc)
+
+#endif  // GET_ATTRDEF_CLASSES
+

--- a/mlir/include/mlir/IR/BuiltinOps.h.inc
+++ b/mlir/include/mlir/IR/BuiltinOps.h.inc
@@ -1,0 +1,208 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Op Declarations                                                            *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#if defined(GET_OP_CLASSES) || defined(GET_OP_FWD_DEFINES)
+#undef GET_OP_FWD_DEFINES
+namespace mlir {
+class ModuleOp;
+} // namespace mlir
+namespace mlir {
+class UnrealizedConversionCastOp;
+} // namespace mlir
+#endif
+
+#ifdef GET_OP_CLASSES
+#undef GET_OP_CLASSES
+
+
+//===----------------------------------------------------------------------===//
+// Local Utility Method Definitions
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::ModuleOp declarations
+//===----------------------------------------------------------------------===//
+
+class ModuleOpAdaptor {
+public:
+  ModuleOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  ModuleOpAdaptor(ModuleOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::StringAttr getSymNameAttr();
+  ::std::optional< ::llvm::StringRef > getSymName();
+  ::mlir::StringAttr getSymVisibilityAttr();
+  ::std::optional< ::llvm::StringRef > getSymVisibility();
+  ::mlir::Region &getBodyRegion();
+  ::mlir::RegionRange getRegions();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class ModuleOp : public ::mlir::Op<ModuleOp, ::mlir::OpTrait::OneRegion, ::mlir::OpTrait::ZeroResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::ZeroOperands, ::mlir::OpTrait::NoRegionArguments, ::mlir::OpTrait::NoTerminator, ::mlir::OpTrait::SingleBlock, ::mlir::OpTrait::OpInvariants, ::mlir::OpTrait::AffineScope, ::mlir::OpTrait::IsIsolatedFromAbove, ::mlir::OpTrait::SymbolTable, ::mlir::SymbolOpInterface::Trait, ::mlir::OpAsmOpInterface::Trait, ::mlir::RegionKindInterface::Trait, ::mlir::OpTrait::HasOnlyGraphRegion> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = ModuleOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    static ::llvm::StringRef attrNames[] = {::llvm::StringRef("sym_name"), ::llvm::StringRef("sym_visibility")};
+    return ::llvm::makeArrayRef(attrNames);
+  }
+
+  ::mlir::StringAttr getSymNameAttrName() {
+    return getAttributeNameForIndex(0);
+  }
+
+  static ::mlir::StringAttr getSymNameAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 0);
+  }
+
+  ::mlir::StringAttr getSymVisibilityAttrName() {
+    return getAttributeNameForIndex(1);
+  }
+
+  static ::mlir::StringAttr getSymVisibilityAttrName(::mlir::OperationName name) {
+    return getAttributeNameForIndex(name, 1);
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("builtin.module");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Region &getBodyRegion();
+  ::mlir::StringAttr getSymNameAttr();
+  ::std::optional< ::llvm::StringRef > getSymName();
+  ::mlir::StringAttr getSymVisibilityAttr();
+  ::std::optional< ::llvm::StringRef > getSymVisibility();
+  void setSymNameAttr(::mlir::StringAttr attr);
+  void setSymName(::std::optional<::llvm::StringRef> attrValue);
+  void setSymVisibilityAttr(::mlir::StringAttr attr);
+  void setSymVisibility(::std::optional<::llvm::StringRef> attrValue);
+  ::mlir::Attribute removeSymNameAttr();
+  ::mlir::Attribute removeSymVisibilityAttr();
+  static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, std::optional<StringRef> name = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult verify();
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+private:
+  ::mlir::StringAttr getAttributeNameForIndex(unsigned index) {
+    return getAttributeNameForIndex((*this)->getName(), index);
+  }
+
+  static ::mlir::StringAttr getAttributeNameForIndex(::mlir::OperationName name, unsigned index) {
+    assert(index < 2 && "invalid attribute index");
+    assert(name.getStringRef() == getOperationName() && "invalid operation name");
+    return name.getRegisteredInfo()->getAttributeNames()[index];
+  }
+
+public:
+  /// Construct a module from the given location with an optional name.
+  static ModuleOp create(Location loc, std::optional<StringRef> name = std::nullopt);
+
+  /// Return the name of this module if present.
+  std::optional<StringRef> getName() { return getSymName(); }
+
+  //===------------------------------------------------------------------===//
+  // SymbolOpInterface Methods
+  //===------------------------------------------------------------------===//
+
+  /// A ModuleOp may optionally define a symbol.
+  bool isOptionalSymbol() { return true; }
+
+  //===------------------------------------------------------------------===//
+  // DataLayoutOpInterface Methods
+  //===------------------------------------------------------------------===//
+
+  DataLayoutSpecInterface getDataLayoutSpec();
+
+  //===------------------------------------------------------------------===//
+  // OpAsmOpInterface Methods
+  //===------------------------------------------------------------------===//
+
+  static ::llvm::StringRef getDefaultDialect() {
+    return "builtin";
+  }
+};
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ModuleOp)
+
+namespace mlir {
+
+//===----------------------------------------------------------------------===//
+// ::mlir::UnrealizedConversionCastOp declarations
+//===----------------------------------------------------------------------===//
+
+class UnrealizedConversionCastOpAdaptor {
+public:
+  UnrealizedConversionCastOpAdaptor(::mlir::ValueRange values, ::mlir::DictionaryAttr attrs = nullptr, ::mlir::RegionRange regions = {});
+
+  UnrealizedConversionCastOpAdaptor(UnrealizedConversionCastOp op);
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::ValueRange getODSOperands(unsigned index);
+  ::mlir::ValueRange getInputs();
+  ::mlir::ValueRange getOperands();
+  ::mlir::DictionaryAttr getAttributes();
+  ::mlir::LogicalResult verify(::mlir::Location loc);
+private:
+  ::mlir::ValueRange odsOperands;
+  ::mlir::DictionaryAttr odsAttrs;
+  ::mlir::RegionRange odsRegions;
+  ::std::optional<::mlir::OperationName> odsOpName;
+};
+class UnrealizedConversionCastOp : public ::mlir::Op<UnrealizedConversionCastOp, ::mlir::OpTrait::ZeroRegions, ::mlir::OpTrait::VariadicResults, ::mlir::OpTrait::ZeroSuccessors, ::mlir::OpTrait::VariadicOperands, ::mlir::OpTrait::OpInvariants, ::mlir::CastOpInterface::Trait, ::mlir::ConditionallySpeculatable::Trait, ::mlir::OpTrait::AlwaysSpeculatableImplTrait, ::mlir::MemoryEffectOpInterface::Trait> {
+public:
+  using Op::Op;
+  using Op::print;
+  using Adaptor = UnrealizedConversionCastOpAdaptor;
+  static ::llvm::ArrayRef<::llvm::StringRef> getAttributeNames() {
+    return {};
+  }
+
+  static constexpr ::llvm::StringLiteral getOperationName() {
+    return ::llvm::StringLiteral("builtin.unrealized_conversion_cast");
+  }
+
+  std::pair<unsigned, unsigned> getODSOperandIndexAndLength(unsigned index);
+  ::mlir::Operation::operand_range getODSOperands(unsigned index);
+  ::mlir::Operation::operand_range getInputs();
+  ::mlir::MutableOperandRange getInputsMutable();
+  std::pair<unsigned, unsigned> getODSResultIndexAndLength(unsigned index);
+  ::mlir::Operation::result_range getODSResults(unsigned index);
+  ::mlir::Operation::result_range getOutputs();
+  static void build(::mlir::OpBuilder &, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange operands, ::llvm::ArrayRef<::mlir::NamedAttribute> attributes = {});
+  ::mlir::LogicalResult verifyInvariantsImpl();
+  ::mlir::LogicalResult verifyInvariants();
+  ::mlir::LogicalResult fold(::llvm::ArrayRef<::mlir::Attribute> operands, ::llvm::SmallVectorImpl<::mlir::OpFoldResult> &results);
+  static bool areCastCompatible(::mlir::TypeRange inputs, ::mlir::TypeRange outputs);
+  static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser, ::mlir::OperationState &result);
+  void print(::mlir::OpAsmPrinter &_odsPrinter);
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects);
+public:
+};
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::UnrealizedConversionCastOp)
+
+
+#endif  // GET_OP_CLASSES
+

--- a/mlir/include/mlir/IR/BuiltinTypeInterfaces.h.inc
+++ b/mlir/include/mlir/IR/BuiltinTypeInterfaces.h.inc
@@ -1,0 +1,320 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class MemRefElementTypeInterface;
+namespace detail {
+struct MemRefElementTypeInterfaceInterfaceTraits {
+  struct Concept {
+  };
+  template<typename ConcreteType>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::MemRefElementTypeInterface;
+    Model() : Concept{} {}
+
+  };
+  template<typename ConcreteType>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::MemRefElementTypeInterface;
+    FallbackModel() : Concept{} {}
+
+  };
+  template<typename ConcreteModel, typename ConcreteType>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteType;
+  };
+};template <typename ConcreteType>
+struct MemRefElementTypeInterfaceTrait;
+
+} // namespace detail
+class MemRefElementTypeInterface : public ::mlir::TypeInterface<MemRefElementTypeInterface, detail::MemRefElementTypeInterfaceInterfaceTraits> {
+public:
+  using ::mlir::TypeInterface<MemRefElementTypeInterface, detail::MemRefElementTypeInterfaceInterfaceTraits>::TypeInterface;
+  template <typename ConcreteType>
+  struct Trait : public detail::MemRefElementTypeInterfaceTrait<ConcreteType> {};
+};
+namespace detail {
+  template <typename ConcreteType>
+  struct MemRefElementTypeInterfaceTrait : public ::mlir::TypeInterface<MemRefElementTypeInterface, detail::MemRefElementTypeInterfaceInterfaceTraits>::Trait<ConcreteType> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class ShapedType;
+namespace detail {
+struct ShapedTypeInterfaceTraits {
+  struct Concept {
+    ::mlir::ShapedType (*cloneWith)(const Concept *impl, ::mlir::Type , ::std::optional<::llvm::ArrayRef<int64_t>>, ::mlir::Type);
+    ::mlir::Type (*getElementType)(const Concept *impl, ::mlir::Type );
+    bool (*hasRank)(const Concept *impl, ::mlir::Type );
+    ::llvm::ArrayRef<int64_t> (*getShape)(const Concept *impl, ::mlir::Type );
+  };
+  template<typename ConcreteType>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::ShapedType;
+    Model() : Concept{cloneWith, getElementType, hasRank, getShape} {}
+
+    static inline ::mlir::ShapedType cloneWith(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::std::optional<::llvm::ArrayRef<int64_t>> shape, ::mlir::Type elementType);
+    static inline ::mlir::Type getElementType(const Concept *impl, ::mlir::Type tablegen_opaque_val);
+    static inline bool hasRank(const Concept *impl, ::mlir::Type tablegen_opaque_val);
+    static inline ::llvm::ArrayRef<int64_t> getShape(const Concept *impl, ::mlir::Type tablegen_opaque_val);
+  };
+  template<typename ConcreteType>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::ShapedType;
+    FallbackModel() : Concept{cloneWith, getElementType, hasRank, getShape} {}
+
+    static inline ::mlir::ShapedType cloneWith(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::std::optional<::llvm::ArrayRef<int64_t>> shape, ::mlir::Type elementType);
+    static inline ::mlir::Type getElementType(const Concept *impl, ::mlir::Type tablegen_opaque_val);
+    static inline bool hasRank(const Concept *impl, ::mlir::Type tablegen_opaque_val);
+    static inline ::llvm::ArrayRef<int64_t> getShape(const Concept *impl, ::mlir::Type tablegen_opaque_val);
+  };
+  template<typename ConcreteModel, typename ConcreteType>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteType;
+  };
+};template <typename ConcreteType>
+struct ShapedTypeTrait;
+
+} // namespace detail
+class ShapedType : public ::mlir::TypeInterface<ShapedType, detail::ShapedTypeInterfaceTraits> {
+public:
+  using ::mlir::TypeInterface<ShapedType, detail::ShapedTypeInterfaceTraits>::TypeInterface;
+  template <typename ConcreteType>
+  struct Trait : public detail::ShapedTypeTrait<ConcreteType> {};
+  /// Returns a clone of this type with the given shape and element
+  /// type. If a shape is not provided, the current shape of the type is used.
+  ::mlir::ShapedType cloneWith(::std::optional<::llvm::ArrayRef<int64_t>> shape, ::mlir::Type elementType) const;
+  /// Returns the element type of this shaped type.
+  ::mlir::Type getElementType() const;
+  /// Returns if this type is ranked, i.e. it has a known number of dimensions.
+  bool hasRank() const;
+  /// Returns the shape of this type if it is ranked, otherwise asserts.
+  ::llvm::ArrayRef<int64_t> getShape() const;
+
+    static constexpr int64_t kDynamic =
+        std::numeric_limits<int64_t>::min();
+
+    /// Whether the given dimension size indicates a dynamic dimension.
+    static constexpr bool isDynamic(int64_t dValue) {
+	return dValue == kDynamic;
+    }
+
+    /// Whether the given shape has any size that indicates a dynamic dimension.
+    static bool isDynamicShape(ArrayRef<int64_t> dSizes) {
+      return any_of(dSizes, [](int64_t dSize) { return isDynamic(dSize); });
+    }
+
+    /// Return the number of elements present in the given shape.
+    static int64_t getNumElements(ArrayRef<int64_t> shape);
+
+    /// Returns the total amount of bits occupied by a value of this type. This
+    /// does not take into account any memory layout or widening constraints,
+    /// e.g. a vector<3xi57> may report to occupy 3x57=171 bit, even though in
+    /// practice it will likely be stored as in a 4xi64 vector register. Fails
+    /// with an assertion if the size cannot be computed statically, e.g. if the
+    /// type has a dynamic shape or if its elemental type does not have a known
+    /// bit width.
+    int64_t getSizeInBits() const;
+  
+
+    /// Return a clone of this type with the given new shape and element type.
+    auto clone(::llvm::ArrayRef<int64_t> shape, Type elementType) {
+      return (*this).cloneWith(shape, elementType);
+    }
+    /// Return a clone of this type with the given new shape.
+    auto clone(::llvm::ArrayRef<int64_t> shape) {
+      return (*this).cloneWith(shape, (*this).getElementType());
+    }
+    /// Return a clone of this type with the given new element type.
+    auto clone(::mlir::Type elementType) {
+      return (*this).cloneWith(/*shape=*/std::nullopt, elementType);
+    }
+
+    /// If an element type is an integer or a float, return its width. Otherwise,
+    /// abort.
+    unsigned getElementTypeBitWidth() const {
+      return (*this).getElementType().getIntOrFloatBitWidth();
+    }
+
+    /// If this is a ranked type, return the rank. Otherwise, abort.
+    int64_t getRank() const {
+      assert((*this).hasRank() && "cannot query rank of unranked shaped type");
+      return (*this).getShape().size();
+    }
+
+    /// If it has static shape, return the number of elements. Otherwise, abort.
+    int64_t getNumElements() const {
+      assert(hasStaticShape() && "cannot get element count of dynamic shaped type");
+      return ::mlir::ShapedType::getNumElements((*this).getShape());
+    }
+
+    /// Returns true if this dimension has a dynamic size (for ranked types);
+    /// aborts for unranked types.
+    bool isDynamicDim(unsigned idx) const {
+      assert(idx < getRank() && "invalid index for shaped type");
+      return ::mlir::ShapedType::isDynamic((*this).getShape()[idx]);
+    }
+
+    /// Returns if this type has a static shape, i.e. if the type is ranked and
+    /// all dimensions have known size (>= 0).
+    bool hasStaticShape() const {
+      return (*this).hasRank() &&
+             !::mlir::ShapedType::isDynamicShape((*this).getShape());
+    }
+
+    /// Returns if this type has a static shape and the shape is equal to
+    /// `shape` return true.
+    bool hasStaticShape(::llvm::ArrayRef<int64_t> shape) const {
+      return hasStaticShape() && (*this).getShape() == shape;
+    }
+
+    /// If this is a ranked type, return the number of dimensions with dynamic
+    /// size. Otherwise, abort.
+    int64_t getNumDynamicDims() const {
+      return llvm::count_if((*this).getShape(), ::mlir::ShapedType::isDynamic);
+    }
+
+    /// If this is ranked type, return the size of the specified dimension.
+    /// Otherwise, abort.
+    int64_t getDimSize(unsigned idx) const {
+      assert(idx < getRank() && "invalid index for shaped type");
+      return (*this).getShape()[idx];
+    }
+
+    /// Returns the position of the dynamic dimension relative to just the dynamic
+    /// dimensions, given its `index` within the shape.
+    unsigned getDynamicDimIndex(unsigned index) const {
+      assert(index < getRank() && "invalid index");
+      assert(::mlir::ShapedType::isDynamic(getDimSize(index)) && "invalid index");
+      return llvm::count_if((*this).getShape().take_front(index),
+                            ::mlir::ShapedType::isDynamic);
+    }
+  };
+namespace detail {
+  template <typename ConcreteType>
+  struct ShapedTypeTrait : public ::mlir::TypeInterface<ShapedType, detail::ShapedTypeInterfaceTraits>::Trait<ConcreteType> {
+
+    /// Return a clone of this type with the given new shape and element type.
+    auto clone(::llvm::ArrayRef<int64_t> shape, Type elementType) {
+      return (*static_cast<const ConcreteType *>(this)).cloneWith(shape, elementType);
+    }
+    /// Return a clone of this type with the given new shape.
+    auto clone(::llvm::ArrayRef<int64_t> shape) {
+      return (*static_cast<const ConcreteType *>(this)).cloneWith(shape, (*static_cast<const ConcreteType *>(this)).getElementType());
+    }
+    /// Return a clone of this type with the given new element type.
+    auto clone(::mlir::Type elementType) {
+      return (*static_cast<const ConcreteType *>(this)).cloneWith(/*shape=*/std::nullopt, elementType);
+    }
+
+    /// If an element type is an integer or a float, return its width. Otherwise,
+    /// abort.
+    unsigned getElementTypeBitWidth() const {
+      return (*static_cast<const ConcreteType *>(this)).getElementType().getIntOrFloatBitWidth();
+    }
+
+    /// If this is a ranked type, return the rank. Otherwise, abort.
+    int64_t getRank() const {
+      assert((*static_cast<const ConcreteType *>(this)).hasRank() && "cannot query rank of unranked shaped type");
+      return (*static_cast<const ConcreteType *>(this)).getShape().size();
+    }
+
+    /// If it has static shape, return the number of elements. Otherwise, abort.
+    int64_t getNumElements() const {
+      assert(hasStaticShape() && "cannot get element count of dynamic shaped type");
+      return ::mlir::ShapedType::getNumElements((*static_cast<const ConcreteType *>(this)).getShape());
+    }
+
+    /// Returns true if this dimension has a dynamic size (for ranked types);
+    /// aborts for unranked types.
+    bool isDynamicDim(unsigned idx) const {
+      assert(idx < getRank() && "invalid index for shaped type");
+      return ::mlir::ShapedType::isDynamic((*static_cast<const ConcreteType *>(this)).getShape()[idx]);
+    }
+
+    /// Returns if this type has a static shape, i.e. if the type is ranked and
+    /// all dimensions have known size (>= 0).
+    bool hasStaticShape() const {
+      return (*static_cast<const ConcreteType *>(this)).hasRank() &&
+             !::mlir::ShapedType::isDynamicShape((*static_cast<const ConcreteType *>(this)).getShape());
+    }
+
+    /// Returns if this type has a static shape and the shape is equal to
+    /// `shape` return true.
+    bool hasStaticShape(::llvm::ArrayRef<int64_t> shape) const {
+      return hasStaticShape() && (*static_cast<const ConcreteType *>(this)).getShape() == shape;
+    }
+
+    /// If this is a ranked type, return the number of dimensions with dynamic
+    /// size. Otherwise, abort.
+    int64_t getNumDynamicDims() const {
+      return llvm::count_if((*static_cast<const ConcreteType *>(this)).getShape(), ::mlir::ShapedType::isDynamic);
+    }
+
+    /// If this is ranked type, return the size of the specified dimension.
+    /// Otherwise, abort.
+    int64_t getDimSize(unsigned idx) const {
+      assert(idx < getRank() && "invalid index for shaped type");
+      return (*static_cast<const ConcreteType *>(this)).getShape()[idx];
+    }
+
+    /// Returns the position of the dynamic dimension relative to just the dynamic
+    /// dimensions, given its `index` within the shape.
+    unsigned getDynamicDimIndex(unsigned index) const {
+      assert(index < getRank() && "invalid index");
+      assert(::mlir::ShapedType::isDynamic(getDimSize(index)) && "invalid index");
+      return llvm::count_if((*static_cast<const ConcreteType *>(this)).getShape().take_front(index),
+                            ::mlir::ShapedType::isDynamic);
+    }
+  
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteType>
+::mlir::ShapedType detail::ShapedTypeInterfaceTraits::Model<ConcreteType>::cloneWith(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::std::optional<::llvm::ArrayRef<int64_t>> shape, ::mlir::Type elementType) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).cloneWith(shape, elementType);
+}
+template<typename ConcreteType>
+::mlir::Type detail::ShapedTypeInterfaceTraits::Model<ConcreteType>::getElementType(const Concept *impl, ::mlir::Type tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).getElementType();
+}
+template<typename ConcreteType>
+bool detail::ShapedTypeInterfaceTraits::Model<ConcreteType>::hasRank(const Concept *impl, ::mlir::Type tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).hasRank();
+}
+template<typename ConcreteType>
+::llvm::ArrayRef<int64_t> detail::ShapedTypeInterfaceTraits::Model<ConcreteType>::getShape(const Concept *impl, ::mlir::Type tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).getShape();
+}
+template<typename ConcreteType>
+::mlir::ShapedType detail::ShapedTypeInterfaceTraits::FallbackModel<ConcreteType>::cloneWith(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::std::optional<::llvm::ArrayRef<int64_t>> shape, ::mlir::Type elementType) {
+  return static_cast<const ConcreteType *>(impl)->cloneWith(tablegen_opaque_val, shape, elementType);
+}
+template<typename ConcreteType>
+::mlir::Type detail::ShapedTypeInterfaceTraits::FallbackModel<ConcreteType>::getElementType(const Concept *impl, ::mlir::Type tablegen_opaque_val) {
+  return static_cast<const ConcreteType *>(impl)->getElementType(tablegen_opaque_val);
+}
+template<typename ConcreteType>
+bool detail::ShapedTypeInterfaceTraits::FallbackModel<ConcreteType>::hasRank(const Concept *impl, ::mlir::Type tablegen_opaque_val) {
+  return static_cast<const ConcreteType *>(impl)->hasRank(tablegen_opaque_val);
+}
+template<typename ConcreteType>
+::llvm::ArrayRef<int64_t> detail::ShapedTypeInterfaceTraits::FallbackModel<ConcreteType>::getShape(const Concept *impl, ::mlir::Type tablegen_opaque_val) {
+  return static_cast<const ConcreteType *>(impl)->getShape(tablegen_opaque_val);
+}
+} // namespace mlir

--- a/mlir/include/mlir/IR/BuiltinTypes.h.inc
+++ b/mlir/include/mlir/IR/BuiltinTypes.h.inc
@@ -1,0 +1,395 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* TypeDef Declarations                                                       *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifdef GET_TYPEDEF_CLASSES
+#undef GET_TYPEDEF_CLASSES
+
+
+namespace mlir {
+class AsmParser;
+class AsmPrinter;
+} // namespace mlir
+namespace mlir {
+class BFloat16Type;
+class ComplexType;
+class Float128Type;
+class Float16Type;
+class Float32Type;
+class Float64Type;
+class Float80Type;
+class Float8E4M3FNType;
+class Float8E5M2Type;
+class FunctionType;
+class IndexType;
+class IntegerType;
+class MemRefType;
+class NoneType;
+class OpaqueType;
+class RankedTensorType;
+class TupleType;
+class UnrankedMemRefType;
+class UnrankedTensorType;
+class VectorType;
+class BFloat16Type : public ::mlir::Type::TypeBase<BFloat16Type, ::mlir::FloatType, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static BFloat16Type get(MLIRContext *context);
+};
+namespace detail {
+struct ComplexTypeStorage;
+} // namespace detail
+class ComplexType : public ::mlir::Type::TypeBase<ComplexType, ::mlir::Type, detail::ComplexTypeStorage> {
+public:
+  using Base::Base;
+  using Base::getChecked;
+  static ComplexType get(Type elementType);
+  static ComplexType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType);
+  Type getElementType() const;
+};
+class Float128Type : public ::mlir::Type::TypeBase<Float128Type, ::mlir::FloatType, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static Float128Type get(MLIRContext *context);
+};
+class Float16Type : public ::mlir::Type::TypeBase<Float16Type, ::mlir::FloatType, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static Float16Type get(MLIRContext *context);
+};
+class Float32Type : public ::mlir::Type::TypeBase<Float32Type, ::mlir::FloatType, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static Float32Type get(MLIRContext *context);
+};
+class Float64Type : public ::mlir::Type::TypeBase<Float64Type, ::mlir::FloatType, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static Float64Type get(MLIRContext *context);
+};
+class Float80Type : public ::mlir::Type::TypeBase<Float80Type, ::mlir::FloatType, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static Float80Type get(MLIRContext *context);
+};
+class Float8E4M3FNType : public ::mlir::Type::TypeBase<Float8E4M3FNType, ::mlir::FloatType, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static Float8E4M3FNType get(MLIRContext *context);
+};
+class Float8E5M2Type : public ::mlir::Type::TypeBase<Float8E5M2Type, ::mlir::FloatType, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static Float8E5M2Type get(MLIRContext *context);
+};
+namespace detail {
+struct FunctionTypeStorage;
+} // namespace detail
+class FunctionType : public ::mlir::Type::TypeBase<FunctionType, ::mlir::Type, detail::FunctionTypeStorage, ::mlir::SubElementTypeInterface::Trait> {
+public:
+  using Base::Base;
+  /// Input types.
+  unsigned getNumInputs() const;
+  Type getInput(unsigned i) const { return getInputs()[i]; }
+
+  /// Result types.
+  unsigned getNumResults() const;
+  Type getResult(unsigned i) const { return getResults()[i]; }
+
+  /// Returns a clone of this function type with the given argument
+  /// and result types.
+  FunctionType clone(TypeRange inputs, TypeRange results) const;
+
+  /// Returns a new function type with the specified arguments and results
+  /// inserted.
+  FunctionType getWithArgsAndResults(ArrayRef<unsigned> argIndices,
+                                     TypeRange argTypes,
+                                     ArrayRef<unsigned> resultIndices,
+                                     TypeRange resultTypes);
+
+  /// Returns a new function type without the specified arguments and results.
+  FunctionType getWithoutArgsAndResults(const BitVector &argIndices,
+                                        const BitVector &resultIndices);
+  static FunctionType get(::mlir::MLIRContext *context, TypeRange inputs, TypeRange results);
+  ArrayRef<Type> getInputs() const;
+  ArrayRef<Type> getResults() const;
+};
+class IndexType : public ::mlir::Type::TypeBase<IndexType, ::mlir::Type, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static IndexType get(MLIRContext *context);
+
+  /// Storage bit width used for IndexType by internal compiler data
+  /// structures.
+  static constexpr unsigned kInternalStorageBitWidth = 64;
+};
+namespace detail {
+struct IntegerTypeStorage;
+} // namespace detail
+class IntegerType : public ::mlir::Type::TypeBase<IntegerType, ::mlir::Type, detail::IntegerTypeStorage> {
+public:
+  using Base::Base;
+  /// Signedness semantics.
+  enum SignednessSemantics : uint32_t {
+    Signless, /// No signedness semantics
+    Signed,   /// Signed integer
+    Unsigned, /// Unsigned integer
+  };
+
+  /// Return true if this is a signless integer type.
+  bool isSignless() const { return getSignedness() == Signless; }
+  /// Return true if this is a signed integer type.
+  bool isSigned() const { return getSignedness() == Signed; }
+  /// Return true if this is an unsigned integer type.
+  bool isUnsigned() const { return getSignedness() == Unsigned; }
+
+  /// Get or create a new IntegerType with the same signedness as `this` and a
+  /// bitwidth scaled by `scale`.
+  /// Return null if the scaled element type cannot be represented.
+  IntegerType scaleElementBitwidth(unsigned scale);
+
+  /// Integer representation maximal bitwidth.
+  /// Note: This is aligned with the maximum width of llvm::IntegerType.
+  static constexpr unsigned kMaxWidth = (1 << 24) - 1;
+  using Base::getChecked;
+  static IntegerType get(::mlir::MLIRContext *context, unsigned width, SignednessSemantics signedness = Signless);
+  static IntegerType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::mlir::MLIRContext *context, unsigned width, SignednessSemantics signedness = Signless);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, unsigned width, SignednessSemantics signedness);
+  unsigned getWidth() const;
+  SignednessSemantics getSignedness() const;
+};
+namespace detail {
+struct MemRefTypeStorage;
+} // namespace detail
+class MemRefType : public ::mlir::Type::TypeBase<MemRefType, BaseMemRefType, detail::MemRefTypeStorage, ::mlir::SubElementTypeInterface::Trait, ::mlir::ShapedType::Trait> {
+public:
+  using Base::Base;
+  using ShapedType::Trait<MemRefType>::clone;
+  using ShapedType::Trait<MemRefType>::getElementTypeBitWidth;
+  using ShapedType::Trait<MemRefType>::getRank;
+  using ShapedType::Trait<MemRefType>::getNumElements;
+  using ShapedType::Trait<MemRefType>::isDynamicDim;
+  using ShapedType::Trait<MemRefType>::hasStaticShape;
+  using ShapedType::Trait<MemRefType>::getNumDynamicDims;
+  using ShapedType::Trait<MemRefType>::getDimSize;
+  using ShapedType::Trait<MemRefType>::getDynamicDimIndex;
+
+  /// This is a builder type that keeps local references to arguments.
+  /// Arguments that are passed into the builder must outlive the builder.
+  class Builder;
+
+  /// [deprecated] Returns the memory space in old raw integer representation.
+  /// New `Attribute getMemorySpace()` method should be used instead.
+  unsigned getMemorySpaceAsInt() const;
+
+  using Base::getChecked;
+  static MemRefType get(ArrayRef<int64_t> shape, Type elementType, MemRefLayoutAttrInterface layout = {}, Attribute memorySpace = {});
+  static MemRefType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ArrayRef<int64_t> shape, Type elementType, MemRefLayoutAttrInterface layout = {}, Attribute memorySpace = {});
+  static MemRefType get(ArrayRef<int64_t> shape, Type elementType, AffineMap map, Attribute memorySpace = {});
+  static MemRefType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ArrayRef<int64_t> shape, Type elementType, AffineMap map, Attribute memorySpace = {});
+  static MemRefType get(ArrayRef<int64_t> shape, Type elementType, AffineMap map, unsigned memorySpaceInd);
+  static MemRefType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ArrayRef<int64_t> shape, Type elementType, AffineMap map, unsigned memorySpaceInd);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::llvm::ArrayRef<int64_t> shape, Type elementType, MemRefLayoutAttrInterface layout, Attribute memorySpace);
+  ::llvm::ArrayRef<int64_t> getShape() const;
+  Type getElementType() const;
+  MemRefLayoutAttrInterface getLayout() const;
+  Attribute getMemorySpace() const;
+};
+class NoneType : public ::mlir::Type::TypeBase<NoneType, ::mlir::Type, ::mlir::TypeStorage> {
+public:
+  using Base::Base;
+  static NoneType get(MLIRContext *context);
+};
+namespace detail {
+struct OpaqueTypeStorage;
+} // namespace detail
+class OpaqueType : public ::mlir::Type::TypeBase<OpaqueType, ::mlir::Type, detail::OpaqueTypeStorage> {
+public:
+  using Base::Base;
+  using Base::getChecked;
+  static OpaqueType get(StringAttr dialectNamespace, StringRef typeData = {});
+  static OpaqueType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, StringAttr dialectNamespace, StringRef typeData = {});
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, StringAttr dialectNamespace, ::llvm::StringRef typeData);
+  StringAttr getDialectNamespace() const;
+  ::llvm::StringRef getTypeData() const;
+};
+namespace detail {
+struct RankedTensorTypeStorage;
+} // namespace detail
+class RankedTensorType : public ::mlir::Type::TypeBase<RankedTensorType, TensorType, detail::RankedTensorTypeStorage, ::mlir::SubElementTypeInterface::Trait, ::mlir::ShapedType::Trait> {
+public:
+  using Base::Base;
+  using ShapedType::Trait<RankedTensorType>::clone;
+  using ShapedType::Trait<RankedTensorType>::getElementTypeBitWidth;
+  using ShapedType::Trait<RankedTensorType>::getRank;
+  using ShapedType::Trait<RankedTensorType>::getNumElements;
+  using ShapedType::Trait<RankedTensorType>::isDynamicDim;
+  using ShapedType::Trait<RankedTensorType>::hasStaticShape;
+  using ShapedType::Trait<RankedTensorType>::getNumDynamicDims;
+  using ShapedType::Trait<RankedTensorType>::getDimSize;
+  using ShapedType::Trait<RankedTensorType>::getDynamicDimIndex;
+
+  /// This is a builder type that keeps local references to arguments.
+  /// Arguments that are passed into the builder must outlive the builder.
+  class Builder;
+  using Base::getChecked;
+  static RankedTensorType get(ArrayRef<int64_t> shape, Type elementType, Attribute encoding = {});
+  static RankedTensorType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ArrayRef<int64_t> shape, Type elementType, Attribute encoding = {});
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::llvm::ArrayRef<int64_t> shape, Type elementType, Attribute encoding);
+  ::llvm::ArrayRef<int64_t> getShape() const;
+  Type getElementType() const;
+  Attribute getEncoding() const;
+};
+namespace detail {
+struct TupleTypeStorage;
+} // namespace detail
+class TupleType : public ::mlir::Type::TypeBase<TupleType, ::mlir::Type, detail::TupleTypeStorage, ::mlir::SubElementTypeInterface::Trait> {
+public:
+  using Base::Base;
+  /// Accumulate the types contained in this tuple and tuples nested within
+  /// it. Note that this only flattens nested tuples, not any other container
+  /// type, e.g. a tuple<i32, tensor<i32>, tuple<f32, tuple<i64>>> is
+  /// flattened to (i32, tensor<i32>, f32, i64)
+  void getFlattenedTypes(SmallVectorImpl<Type> &types);
+
+  /// Return the number of held types.
+  size_t size() const;
+
+  /// Iterate over the held elements.
+  using iterator = ArrayRef<Type>::iterator;
+  iterator begin() const { return getTypes().begin(); }
+  iterator end() const { return getTypes().end(); }
+
+  /// Return the element type at index 'index'.
+  Type getType(size_t index) const {
+    assert(index < size() && "invalid index for tuple type");
+    return getTypes()[index];
+  }
+  static TupleType get(::mlir::MLIRContext *context, TypeRange elementTypes);
+  static TupleType get(::mlir::MLIRContext *context);
+  ArrayRef<Type> getTypes() const;
+};
+namespace detail {
+struct UnrankedMemRefTypeStorage;
+} // namespace detail
+class UnrankedMemRefType : public ::mlir::Type::TypeBase<UnrankedMemRefType, BaseMemRefType, detail::UnrankedMemRefTypeStorage, ::mlir::SubElementTypeInterface::Trait, ::mlir::ShapedType::Trait> {
+public:
+  using Base::Base;
+  using ShapedType::Trait<UnrankedMemRefType>::clone;
+  using ShapedType::Trait<UnrankedMemRefType>::getElementTypeBitWidth;
+  using ShapedType::Trait<UnrankedMemRefType>::getRank;
+  using ShapedType::Trait<UnrankedMemRefType>::getNumElements;
+  using ShapedType::Trait<UnrankedMemRefType>::isDynamicDim;
+  using ShapedType::Trait<UnrankedMemRefType>::hasStaticShape;
+  using ShapedType::Trait<UnrankedMemRefType>::getNumDynamicDims;
+  using ShapedType::Trait<UnrankedMemRefType>::getDimSize;
+  using ShapedType::Trait<UnrankedMemRefType>::getDynamicDimIndex;
+
+  ArrayRef<int64_t> getShape() const { return std::nullopt; }
+
+  /// [deprecated] Returns the memory space in old raw integer representation.
+  /// New `Attribute getMemorySpace()` method should be used instead.
+  unsigned getMemorySpaceAsInt() const;
+  using Base::getChecked;
+  static UnrankedMemRefType get(Type elementType, Attribute memorySpace);
+  static UnrankedMemRefType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, Attribute memorySpace);
+  static UnrankedMemRefType get(Type elementType, unsigned memorySpace);
+  static UnrankedMemRefType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, unsigned memorySpace);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType, Attribute memorySpace);
+  Type getElementType() const;
+  Attribute getMemorySpace() const;
+};
+namespace detail {
+struct UnrankedTensorTypeStorage;
+} // namespace detail
+class UnrankedTensorType : public ::mlir::Type::TypeBase<UnrankedTensorType, TensorType, detail::UnrankedTensorTypeStorage, ::mlir::SubElementTypeInterface::Trait, ::mlir::ShapedType::Trait> {
+public:
+  using Base::Base;
+  using ShapedType::Trait<UnrankedTensorType>::clone;
+  using ShapedType::Trait<UnrankedTensorType>::getElementTypeBitWidth;
+  using ShapedType::Trait<UnrankedTensorType>::getRank;
+  using ShapedType::Trait<UnrankedTensorType>::getNumElements;
+  using ShapedType::Trait<UnrankedTensorType>::isDynamicDim;
+  using ShapedType::Trait<UnrankedTensorType>::hasStaticShape;
+  using ShapedType::Trait<UnrankedTensorType>::getNumDynamicDims;
+  using ShapedType::Trait<UnrankedTensorType>::getDimSize;
+  using ShapedType::Trait<UnrankedTensorType>::getDynamicDimIndex;
+
+  ArrayRef<int64_t> getShape() const { return std::nullopt; }
+  using Base::getChecked;
+  static UnrankedTensorType get(Type elementType);
+  static UnrankedTensorType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, Type elementType);
+  Type getElementType() const;
+};
+namespace detail {
+struct VectorTypeStorage;
+} // namespace detail
+class VectorType : public ::mlir::Type::TypeBase<VectorType, Type, detail::VectorTypeStorage, ::mlir::SubElementTypeInterface::Trait, ::mlir::ShapedType::Trait> {
+public:
+  using Base::Base;
+  /// This is a builder type that keeps local references to arguments.
+  /// Arguments that are passed into the builder must outlive the builder.
+  class Builder;
+
+  /// Returns true if the given type can be used as an element of a vector
+  /// type. In particular, vectors can consist of integer, index, or float
+  /// primitives.
+  static bool isValidElementType(Type t) {
+    return t.isa<IntegerType, IndexType, FloatType>();
+  }
+
+  /// Returns true if the vector contains scalable dimensions.
+  bool isScalable() const {
+    return getNumScalableDims() > 0;
+  }
+
+  /// Get or create a new VectorType with the same shape as `this` and an
+  /// element type of bitwidth scaled by `scale`.
+  /// Return null if the scaled element type cannot be represented.
+  VectorType scaleElementBitwidth(unsigned scale);
+
+  /// Returns if this type is ranked (always true).
+  bool hasRank() const { return true; }
+
+  /// Clone this vector type with the given shape and element type. If the
+  /// provided shape is `None`, the current shape of the type is used.
+  VectorType cloneWith(std::optional<ArrayRef<int64_t>> shape,
+                       Type elementType) const;
+  using Base::getChecked;
+  static VectorType get(ArrayRef<int64_t> shape, Type elementType, unsigned numScalableDims = 0);
+  static VectorType getChecked(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ArrayRef<int64_t> shape, Type elementType, unsigned numScalableDims = 0);
+  static ::mlir::LogicalResult verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::llvm::ArrayRef<int64_t> shape, Type elementType, unsigned numScalableDims);
+  ::llvm::ArrayRef<int64_t> getShape() const;
+  Type getElementType() const;
+  unsigned getNumScalableDims() const;
+};
+} // namespace mlir
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::BFloat16Type)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::ComplexType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::Float128Type)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::Float16Type)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::Float32Type)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::Float64Type)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::Float80Type)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::Float8E4M3FNType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::Float8E5M2Type)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::FunctionType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::IndexType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::IntegerType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::MemRefType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::NoneType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::OpaqueType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::RankedTensorType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::TupleType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::UnrankedMemRefType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::UnrankedTensorType)
+MLIR_DECLARE_EXPLICIT_TYPE_ID(::mlir::VectorType)
+
+#endif  // GET_TYPEDEF_CLASSES
+

--- a/mlir/include/mlir/IR/FunctionOpInterfaces.h.inc
+++ b/mlir/include/mlir/IR/FunctionOpInterfaces.h.inc
@@ -1,0 +1,1184 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class FunctionOpInterface;
+namespace detail {
+struct FunctionOpInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::Type (*getFunctionType)(const Concept *impl, ::mlir::Operation *);
+    void (*setFunctionTypeAttr)(const Concept *impl, ::mlir::Operation *, ::mlir::TypeAttr);
+    ::mlir::ArrayAttr (*getArgAttrsAttr)(const Concept *impl, ::mlir::Operation *);
+    ::mlir::ArrayAttr (*getResAttrsAttr)(const Concept *impl, ::mlir::Operation *);
+    void (*setArgAttrsAttr)(const Concept *impl, ::mlir::Operation *, ::mlir::ArrayAttr);
+    void (*setResAttrsAttr)(const Concept *impl, ::mlir::Operation *, ::mlir::ArrayAttr);
+    ::mlir::Attribute (*removeArgAttrsAttr)(const Concept *impl, ::mlir::Operation *);
+    ::mlir::Attribute (*removeResAttrsAttr)(const Concept *impl, ::mlir::Operation *);
+    ::llvm::ArrayRef<::mlir::Type> (*getArgumentTypes)(const Concept *impl, ::mlir::Operation *);
+    ::llvm::ArrayRef<::mlir::Type> (*getResultTypes)(const Concept *impl, ::mlir::Operation *);
+    ::mlir::Type (*cloneTypeWith)(const Concept *impl, ::mlir::Operation *, ::mlir::TypeRange, ::mlir::TypeRange);
+    ::mlir::LogicalResult (*verifyBody)(const Concept *impl, ::mlir::Operation *);
+    ::mlir::LogicalResult (*verifyType)(const Concept *impl, ::mlir::Operation *);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::FunctionOpInterface;
+    Model() : Concept{getFunctionType, setFunctionTypeAttr, getArgAttrsAttr, getResAttrsAttr, setArgAttrsAttr, setResAttrsAttr, removeArgAttrsAttr, removeResAttrsAttr, getArgumentTypes, getResultTypes, cloneTypeWith, verifyBody, verifyType} {}
+
+    static inline ::mlir::Type getFunctionType(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setFunctionTypeAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::TypeAttr type);
+    static inline ::mlir::ArrayAttr getArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::ArrayAttr getResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::ArrayAttr attrs);
+    static inline void setResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::ArrayAttr attrs);
+    static inline ::mlir::Attribute removeArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::Attribute removeResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::llvm::ArrayRef<::mlir::Type> getArgumentTypes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::llvm::ArrayRef<::mlir::Type> getResultTypes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::Type cloneTypeWith(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::TypeRange inputs, ::mlir::TypeRange results);
+    static inline ::mlir::LogicalResult verifyBody(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::LogicalResult verifyType(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::FunctionOpInterface;
+    FallbackModel() : Concept{getFunctionType, setFunctionTypeAttr, getArgAttrsAttr, getResAttrsAttr, setArgAttrsAttr, setResAttrsAttr, removeArgAttrsAttr, removeResAttrsAttr, getArgumentTypes, getResultTypes, cloneTypeWith, verifyBody, verifyType} {}
+
+    static inline ::mlir::Type getFunctionType(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setFunctionTypeAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::TypeAttr type);
+    static inline ::mlir::ArrayAttr getArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::ArrayAttr getResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::ArrayAttr attrs);
+    static inline void setResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::ArrayAttr attrs);
+    static inline ::mlir::Attribute removeArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::Attribute removeResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::llvm::ArrayRef<::mlir::Type> getArgumentTypes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::llvm::ArrayRef<::mlir::Type> getResultTypes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::Type cloneTypeWith(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::TypeRange inputs, ::mlir::TypeRange results);
+    static inline ::mlir::LogicalResult verifyBody(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::LogicalResult verifyType(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+    ::mlir::Type cloneTypeWith(::mlir::Operation *tablegen_opaque_val, ::mlir::TypeRange inputs, ::mlir::TypeRange results) const;
+    ::mlir::LogicalResult verifyBody(::mlir::Operation *tablegen_opaque_val) const;
+    ::mlir::LogicalResult verifyType(::mlir::Operation *tablegen_opaque_val) const;
+  };
+};template <typename ConcreteOp>
+struct FunctionOpInterfaceTrait;
+
+} // namespace detail
+class FunctionOpInterface : public ::mlir::OpInterface<FunctionOpInterface, detail::FunctionOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<FunctionOpInterface, detail::FunctionOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::FunctionOpInterfaceTrait<ConcreteOp> {};
+  /// Returns the type of the function.
+  ::mlir::Type getFunctionType();
+  /// Set the type of the function. This method should perform an unsafe
+  /// modification to the function type; it should not update argument or
+  /// result attributes.
+  void setFunctionTypeAttr(::mlir::TypeAttr type);
+  /// Get the array of argument attribute dictionaries. The method should return
+  /// an array attribute containing only dictionary attributes equal in number
+  /// to the number of function arguments. Alternatively, the method can return
+  /// null to indicate that the function has no argument attributes.
+  ::mlir::ArrayAttr getArgAttrsAttr();
+  /// Get the array of result attribute dictionaries. The method should return
+  /// an array attribute containing only dictionary attributes equal in number
+  /// to the number of function results. Alternatively, the method can return
+  /// null to indicate that the function has no result attributes.
+  ::mlir::ArrayAttr getResAttrsAttr();
+  /// Set the array of argument attribute dictionaries.
+  void setArgAttrsAttr(::mlir::ArrayAttr attrs);
+  /// Set the array of result attribute dictionaries.
+  void setResAttrsAttr(::mlir::ArrayAttr attrs);
+  /// Remove the array of argument attribute dictionaries. This is the same as
+  /// setting all argument attributes to an empty dictionary. The method should
+  /// return the removed attribute.
+  ::mlir::Attribute removeArgAttrsAttr();
+  /// Remove the array of result attribute dictionaries. This is the same as
+  /// setting all result attributes to an empty dictionary. The method should
+  /// return the removed attribute.
+  ::mlir::Attribute removeResAttrsAttr();
+  /// Returns the function argument types based exclusively on
+  /// the type (to allow for this method may be called on function
+  /// declarations).
+  ::llvm::ArrayRef<::mlir::Type> getArgumentTypes();
+  /// Returns the function result types based exclusively on
+  /// the type (to allow for this method may be called on function
+  /// declarations).
+  ::llvm::ArrayRef<::mlir::Type> getResultTypes();
+  /// Returns a clone of the function type with the given argument and
+  /// result types.
+  /// 
+  /// Note: The default implementation assumes the function type has
+  ///       an appropriate clone method:
+  ///         `Type clone(ArrayRef<Type> inputs, ArrayRef<Type> results)`
+  ::mlir::Type cloneTypeWith(::mlir::TypeRange inputs, ::mlir::TypeRange results);
+  /// Verify the contents of the body of this function.
+  /// 
+  /// Note: The default implementation merely checks that if the entry block
+  /// exists, it has the same number and type of arguments as the function type.
+  ::mlir::LogicalResult verifyBody();
+  /// Verify the type attribute of the function for derived op-specific
+  /// invariants.
+  ::mlir::LogicalResult verifyType();
+
+    //===------------------------------------------------------------------===//
+    // Name
+    //===------------------------------------------------------------------===//
+
+    /// Return the name of the function.
+    StringRef getName() { return SymbolTable::getSymbolName(*this); }
+  
+
+    /// Block list iterator types.
+    using BlockListType = Region::BlockListType;
+    using iterator = BlockListType::iterator;
+    using reverse_iterator = BlockListType::reverse_iterator;
+
+    /// Block argument iterator types.
+    using BlockArgListType = Region::BlockArgListType;
+    using args_iterator = BlockArgListType::iterator;
+
+    //===------------------------------------------------------------------===//
+    // Body Handling
+    //===------------------------------------------------------------------===//
+
+    /// Returns true if this function is external, i.e. it has no body.
+    bool isExternal() { return empty(); }
+
+    /// Return the region containing the body of this function.
+    Region &getFunctionBody() { return (*this)->getRegion(0); }
+
+    /// Delete all blocks from this function.
+    void eraseBody() {
+      getFunctionBody().dropAllReferences();
+      getFunctionBody().getBlocks().clear();
+    }
+
+    /// Return the list of blocks within the function body.
+    BlockListType &getBlocks() { return getFunctionBody().getBlocks(); }
+
+    iterator begin() { return getFunctionBody().begin(); }
+    iterator end() { return getFunctionBody().end(); }
+    reverse_iterator rbegin() { return getFunctionBody().rbegin(); }
+    reverse_iterator rend() { return getFunctionBody().rend(); }
+
+    /// Returns true if this function has no blocks within the body.
+    bool empty() { return getFunctionBody().empty(); }
+
+    /// Push a new block to the back of the body region.
+    void push_back(Block *block) { getFunctionBody().push_back(block); }
+
+    /// Push a new block to the front of the body region.
+    void push_front(Block *block) { getFunctionBody().push_front(block); }
+
+    /// Return the last block in the body region.
+    Block &back() { return getFunctionBody().back(); }
+
+    /// Return the first block in the body region.
+    Block &front() { return getFunctionBody().front(); }
+
+    /// Add an entry block to an empty function, and set up the block arguments
+    /// to match the signature of the function. The newly inserted entry block
+    /// is returned.
+    Block *addEntryBlock() {
+      assert(empty() && "function already has an entry block");
+      Block *entry = new Block();
+      push_back(entry);
+
+      // FIXME: Allow for passing in locations for these arguments instead of using
+      // the operations location.
+      ArrayRef<Type> inputTypes = (*this).getArgumentTypes();
+      SmallVector<Location> locations(inputTypes.size(),
+                                      (*this).getOperation()->getLoc());
+      entry->addArguments(inputTypes, locations);
+      return entry;
+    }
+
+    /// Add a normal block to the end of the function's block list. The function
+    /// should at least already have an entry block.
+    Block *addBlock() {
+      assert(!empty() && "function should at least have an entry block");
+      push_back(new Block());
+      return &back();
+    }
+
+    //===------------------------------------------------------------------===//
+    // Type Attribute Handling
+    //===------------------------------------------------------------------===//
+
+    /// Change the type of this function in place. This is an extremely dangerous
+    /// operation and it is up to the caller to ensure that this is legal for
+    /// this function, and to restore invariants:
+    ///  - the entry block args must be updated to match the function params.
+    ///  - the argument/result attributes may need an update: if the new type
+    ///    has less parameters we drop the extra attributes, if there are more
+    ///    parameters they won't have any attributes.
+    void setType(Type newType) {
+      function_interface_impl::setFunctionType(this->getOperation(), newType);
+    }
+
+    //===------------------------------------------------------------------===//
+    // Argument and Result Handling
+    //===------------------------------------------------------------------===//
+
+    /// Returns the number of function arguments.
+    unsigned getNumArguments() { return (*this).getArgumentTypes().size(); }
+
+    /// Returns the number of function results.
+    unsigned getNumResults() { return (*this).getResultTypes().size(); }
+
+    /// Returns the entry block function argument at the given index.
+    BlockArgument getArgument(unsigned idx) {
+      return getFunctionBody().getArgument(idx);
+    }
+
+    /// Support argument iteration.
+    args_iterator args_begin() { return getFunctionBody().args_begin(); }
+    args_iterator args_end() { return getFunctionBody().args_end(); }
+    BlockArgListType getArguments() { return getFunctionBody().getArguments(); }
+
+    /// Insert a single argument of type `argType` with attributes `argAttrs` and
+    /// location `argLoc` at `argIndex`.
+    void insertArgument(unsigned argIndex, Type argType, DictionaryAttr argAttrs,
+                        Location argLoc) {
+      insertArguments({argIndex}, {argType}, {argAttrs}, {argLoc});
+    }
+
+    /// Inserts arguments with the listed types, attributes, and locations at the
+    /// listed indices. `argIndices` must be sorted. Arguments are inserted in the
+    /// order they are listed, such that arguments with identical index will
+    /// appear in the same order that they were listed here.
+    void insertArguments(ArrayRef<unsigned> argIndices, TypeRange argTypes,
+                        ArrayRef<DictionaryAttr> argAttrs,
+                        ArrayRef<Location> argLocs) {
+      unsigned originalNumArgs = (*this).getNumArguments();
+      Type newType = (*this).getTypeWithArgsAndResults(
+          argIndices, argTypes, /*resultIndices=*/{}, /*resultTypes=*/{});
+      function_interface_impl::insertFunctionArguments(
+          this->getOperation(), argIndices, argTypes, argAttrs, argLocs,
+          originalNumArgs, newType);
+    }
+
+    /// Insert a single result of type `resultType` at `resultIndex`.
+    void insertResult(unsigned resultIndex, Type resultType,
+                      DictionaryAttr resultAttrs) {
+      insertResults({resultIndex}, {resultType}, {resultAttrs});
+    }
+
+    /// Inserts results with the listed types at the listed indices.
+    /// `resultIndices` must be sorted. Results are inserted in the order they are
+    /// listed, such that results with identical index will appear in the same
+    /// order that they were listed here.
+    void insertResults(ArrayRef<unsigned> resultIndices, TypeRange resultTypes,
+                      ArrayRef<DictionaryAttr> resultAttrs) {
+      unsigned originalNumResults = (*this).getNumResults();
+      Type newType = (*this).getTypeWithArgsAndResults(
+        /*argIndices=*/{}, /*argTypes=*/{}, resultIndices, resultTypes);
+      function_interface_impl::insertFunctionResults(
+          this->getOperation(), resultIndices, resultTypes, resultAttrs,
+          originalNumResults, newType);
+    }
+
+    /// Erase a single argument at `argIndex`.
+    void eraseArgument(unsigned argIndex) {
+      BitVector argsToErase((*this).getNumArguments());
+      argsToErase.set(argIndex);
+      eraseArguments(argsToErase);
+    }
+
+    /// Erases the arguments listed in `argIndices`.
+    void eraseArguments(const BitVector &argIndices) {
+      Type newType = (*this).getTypeWithoutArgs(argIndices);
+      function_interface_impl::eraseFunctionArguments(
+        this->getOperation(), argIndices, newType);
+    }
+
+    /// Erase a single result at `resultIndex`.
+    void eraseResult(unsigned resultIndex) {
+      BitVector resultsToErase((*this).getNumResults());
+      resultsToErase.set(resultIndex);
+      eraseResults(resultsToErase);
+    }
+
+    /// Erases the results listed in `resultIndices`.
+    void eraseResults(const BitVector &resultIndices) {
+      Type newType = (*this).getTypeWithoutResults(resultIndices);
+      function_interface_impl::eraseFunctionResults(
+          this->getOperation(), resultIndices, newType);
+    }
+
+    /// Return the type of this function with the specified arguments and
+    /// results inserted. This is used to update the function's signature in
+    /// the `insertArguments` and `insertResults` methods. The arrays must be
+    /// sorted by increasing index.
+    Type getTypeWithArgsAndResults(
+      ArrayRef<unsigned> argIndices, TypeRange argTypes,
+      ArrayRef<unsigned> resultIndices, TypeRange resultTypes) {
+      SmallVector<Type> argStorage, resultStorage;
+      TypeRange newArgTypes = function_interface_impl::insertTypesInto(
+          (*this).getArgumentTypes(), argIndices, argTypes, argStorage);
+      TypeRange newResultTypes = function_interface_impl::insertTypesInto(
+          (*this).getResultTypes(), resultIndices, resultTypes, resultStorage);
+      return (*this).cloneTypeWith(newArgTypes, newResultTypes);
+    }
+
+    /// Return the type of this function without the specified arguments and
+    /// results. This is used to update the function's signature in the
+    /// `eraseArguments` and `eraseResults` methods.
+    Type getTypeWithoutArgsAndResults(
+      const BitVector &argIndices, const BitVector &resultIndices) {
+      SmallVector<Type> argStorage, resultStorage;
+      TypeRange newArgTypes = function_interface_impl::filterTypesOut(
+          (*this).getArgumentTypes(), argIndices, argStorage);
+      TypeRange newResultTypes = function_interface_impl::filterTypesOut(
+          (*this).getResultTypes(), resultIndices, resultStorage);
+      return (*this).cloneTypeWith(newArgTypes, newResultTypes);
+    }
+    Type getTypeWithoutArgs(const BitVector &argIndices) {
+      SmallVector<Type> argStorage;
+      TypeRange newArgTypes = function_interface_impl::filterTypesOut(
+          (*this).getArgumentTypes(), argIndices, argStorage);
+      return (*this).cloneTypeWith(newArgTypes, (*this).getResultTypes());
+    }
+    Type getTypeWithoutResults(const BitVector &resultIndices) {
+      SmallVector<Type> resultStorage;
+      TypeRange newResultTypes = function_interface_impl::filterTypesOut(
+          (*this).getResultTypes(), resultIndices, resultStorage);
+      return (*this).cloneTypeWith((*this).getArgumentTypes(), newResultTypes);
+    }
+
+    //===------------------------------------------------------------------===//
+    // Argument Attributes
+    //===------------------------------------------------------------------===//
+
+    /// Return all of the attributes for the argument at 'index'.
+    ArrayRef<NamedAttribute> getArgAttrs(unsigned index) {
+      return function_interface_impl::getArgAttrs(this->getOperation(), index);
+    }
+
+    /// Return an ArrayAttr containing all argument attribute dictionaries of
+    /// this function, or nullptr if no arguments have attributes.
+    ArrayAttr getAllArgAttrs() { return (*this).getArgAttrsAttr(); }
+
+    /// Return all argument attributes of this function.
+    void getAllArgAttrs(SmallVectorImpl<DictionaryAttr> &result) {
+      if (ArrayAttr argAttrs = getAllArgAttrs()) {
+        auto argAttrRange = argAttrs.template getAsRange<DictionaryAttr>();
+        result.append(argAttrRange.begin(), argAttrRange.end());
+      } else {
+        result.append((*this).getNumArguments(),
+                      DictionaryAttr::get(this->getOperation()->getContext()));
+      }
+    }
+
+    /// Return the specified attribute, if present, for the argument at 'index',
+    /// null otherwise.
+    Attribute getArgAttr(unsigned index, StringAttr name) {
+      auto argDict = getArgAttrDict(index);
+      return argDict ? argDict.get(name) : nullptr;
+    }
+    Attribute getArgAttr(unsigned index, StringRef name) {
+      auto argDict = getArgAttrDict(index);
+      return argDict ? argDict.get(name) : nullptr;
+    }
+
+    template <typename AttrClass>
+    AttrClass getArgAttrOfType(unsigned index, StringAttr name) {
+      return getArgAttr(index, name).template dyn_cast_or_null<AttrClass>();
+    }
+    template <typename AttrClass>
+    AttrClass getArgAttrOfType(unsigned index, StringRef name) {
+      return getArgAttr(index, name).template dyn_cast_or_null<AttrClass>();
+    }
+
+    /// Set the attributes held by the argument at 'index'.
+    void setArgAttrs(unsigned index, ArrayRef<NamedAttribute> attributes) {
+      function_interface_impl::setArgAttrs((*this), index, attributes);
+    }
+
+    /// Set the attributes held by the argument at 'index'. `attributes` may be
+    /// null, in which case any existing argument attributes are removed.
+    void setArgAttrs(unsigned index, DictionaryAttr attributes) {
+      function_interface_impl::setArgAttrs((*this), index, attributes);
+    }
+    void setAllArgAttrs(ArrayRef<DictionaryAttr> attributes) {
+      assert(attributes.size() == (*this).getNumArguments());
+      function_interface_impl::setAllArgAttrDicts(this->getOperation(), attributes);
+    }
+    void setAllArgAttrs(ArrayRef<Attribute> attributes) {
+      assert(attributes.size() == (*this).getNumArguments());
+      function_interface_impl::setAllArgAttrDicts(this->getOperation(), attributes);
+    }
+    void setAllArgAttrs(ArrayAttr attributes) {
+      assert(attributes.size() == (*this).getNumArguments());
+      (*this).setArgAttrsAttr(attributes);
+    }
+
+    /// If the an attribute exists with the specified name, change it to the new
+    /// value. Otherwise, add a new attribute with the specified name/value.
+    void setArgAttr(unsigned index, StringAttr name, Attribute value) {
+      function_interface_impl::setArgAttr((*this), index, name, value);
+    }
+    void setArgAttr(unsigned index, StringRef name, Attribute value) {
+      setArgAttr(index,
+                 StringAttr::get(this->getOperation()->getContext(), name),
+                 value);
+    }
+
+    /// Remove the attribute 'name' from the argument at 'index'. Return the
+    /// attribute that was erased, or nullptr if there was no attribute with
+    /// such name.
+    Attribute removeArgAttr(unsigned index, StringAttr name) {
+      return function_interface_impl::removeArgAttr((*this), index, name);
+    }
+    Attribute removeArgAttr(unsigned index, StringRef name) {
+      return removeArgAttr(
+          index, StringAttr::get(this->getOperation()->getContext(), name));
+    }
+
+    //===------------------------------------------------------------------===//
+    // Result Attributes
+    //===------------------------------------------------------------------===//
+
+    /// Return all of the attributes for the result at 'index'.
+    ArrayRef<NamedAttribute> getResultAttrs(unsigned index) {
+      return function_interface_impl::getResultAttrs(this->getOperation(), index);
+    }
+
+    /// Return an ArrayAttr containing all result attribute dictionaries of this
+    /// function, or nullptr if no result have attributes.
+    ArrayAttr getAllResultAttrs() { return (*this).getResAttrsAttr(); }
+
+    /// Return all result attributes of this function.
+    void getAllResultAttrs(SmallVectorImpl<DictionaryAttr> &result) {
+      if (ArrayAttr argAttrs = getAllResultAttrs()) {
+        auto argAttrRange = argAttrs.template getAsRange<DictionaryAttr>();
+        result.append(argAttrRange.begin(), argAttrRange.end());
+      } else {
+        result.append((*this).getNumResults(),
+                      DictionaryAttr::get(this->getOperation()->getContext()));
+      }
+    }
+
+    /// Return the specified attribute, if present, for the result at 'index',
+    /// null otherwise.
+    Attribute getResultAttr(unsigned index, StringAttr name) {
+      auto argDict = getResultAttrDict(index);
+      return argDict ? argDict.get(name) : nullptr;
+    }
+    Attribute getResultAttr(unsigned index, StringRef name) {
+      auto argDict = getResultAttrDict(index);
+      return argDict ? argDict.get(name) : nullptr;
+    }
+
+    template <typename AttrClass>
+    AttrClass getResultAttrOfType(unsigned index, StringAttr name) {
+      return getResultAttr(index, name).template dyn_cast_or_null<AttrClass>();
+    }
+    template <typename AttrClass>
+    AttrClass getResultAttrOfType(unsigned index, StringRef name) {
+      return getResultAttr(index, name).template dyn_cast_or_null<AttrClass>();
+    }
+
+    /// Set the attributes held by the result at 'index'.
+    void setResultAttrs(unsigned index, ArrayRef<NamedAttribute> attributes) {
+      function_interface_impl::setResultAttrs((*this), index, attributes);
+    }
+
+    /// Set the attributes held by the result at 'index'. `attributes` may be
+    /// null, in which case any existing argument attributes are removed.
+    void setResultAttrs(unsigned index, DictionaryAttr attributes) {
+      function_interface_impl::setResultAttrs((*this), index, attributes);
+    }
+    void setAllResultAttrs(ArrayRef<DictionaryAttr> attributes) {
+      assert(attributes.size() == (*this).getNumResults());
+      function_interface_impl::setAllResultAttrDicts(
+        this->getOperation(), attributes);
+    }
+    void setAllResultAttrs(ArrayRef<Attribute> attributes) {
+      assert(attributes.size() == (*this).getNumResults());
+      function_interface_impl::setAllResultAttrDicts(
+        this->getOperation(), attributes);
+    }
+    void setAllResultAttrs(ArrayAttr attributes) {
+      assert(attributes.size() == (*this).getNumResults());
+      (*this).setResAttrsAttr(attributes);
+    }
+
+    /// If the an attribute exists with the specified name, change it to the new
+    /// value. Otherwise, add a new attribute with the specified name/value.
+    void setResultAttr(unsigned index, StringAttr name, Attribute value) {
+      function_interface_impl::setResultAttr((*this), index, name, value);
+    }
+    void setResultAttr(unsigned index, StringRef name, Attribute value) {
+      setResultAttr(index,
+                    StringAttr::get(this->getOperation()->getContext(), name),
+                    value);
+    }
+
+    /// Remove the attribute 'name' from the result at 'index'. Return the
+    /// attribute that was erased, or nullptr if there was no attribute with
+    /// such name.
+    Attribute removeResultAttr(unsigned index, StringAttr name) {
+      return function_interface_impl::removeResultAttr((*this), index, name);
+    }
+
+    /// Returns the dictionary attribute corresponding to the argument at
+    /// 'index'. If there are no argument attributes at 'index', a null
+    /// attribute is returned.
+    DictionaryAttr getArgAttrDict(unsigned index) {
+      assert(index < (*this).getNumArguments() && "invalid argument number");
+      return function_interface_impl::getArgAttrDict(this->getOperation(), index);
+    }
+
+    /// Returns the dictionary attribute corresponding to the result at 'index'.
+    /// If there are no result attributes at 'index', a null attribute is
+    /// returned.
+    DictionaryAttr getResultAttrDict(unsigned index) {
+      assert(index < (*this).getNumResults() && "invalid result number");
+      return function_interface_impl::getResultAttrDict(this->getOperation(), index);
+    }
+  };
+namespace detail {
+  template <typename ConcreteOp>
+  struct FunctionOpInterfaceTrait : public ::mlir::OpInterface<FunctionOpInterface, detail::FunctionOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+    /// Returns a clone of the function type with the given argument and
+    /// result types.
+    /// 
+    /// Note: The default implementation assumes the function type has
+    ///       an appropriate clone method:
+    ///         `Type clone(ArrayRef<Type> inputs, ArrayRef<Type> results)`
+    ::mlir::Type cloneTypeWith(::mlir::TypeRange inputs, ::mlir::TypeRange results) {
+      return (*static_cast<ConcreteOp *>(this)).getFunctionType().clone(inputs, results);
+    }
+    /// Verify the contents of the body of this function.
+    /// 
+    /// Note: The default implementation merely checks that if the entry block
+    /// exists, it has the same number and type of arguments as the function type.
+    ::mlir::LogicalResult verifyBody() {
+      if ((*static_cast<ConcreteOp *>(this)).isExternal())
+        return success();
+      ArrayRef<Type> fnInputTypes = (*static_cast<ConcreteOp *>(this)).getArgumentTypes();
+      // NOTE: This should just be (*static_cast<ConcreteOp *>(this)).front() but access generically
+      // because the interface methods defined here may be shadowed in
+      // arbitrary ways. https://github.com/llvm/llvm-project/issues/54807
+      Block &entryBlock = (*static_cast<ConcreteOp *>(this))->getRegion(0).front();
+
+      unsigned numArguments = fnInputTypes.size();
+      if (entryBlock.getNumArguments() != numArguments)
+        return (*static_cast<ConcreteOp *>(this)).emitOpError("entry block must have ")
+              << numArguments << " arguments to match function signature";
+
+      for (unsigned i = 0, e = fnInputTypes.size(); i != e; ++i) {
+        Type argType = entryBlock.getArgument(i).getType();
+        if (fnInputTypes[i] != argType) {
+          return (*static_cast<ConcreteOp *>(this)).emitOpError("type of entry block argument #")
+                << i << '(' << argType
+                << ") must match the type of the corresponding argument in "
+                << "function signature(" << fnInputTypes[i] << ')';
+        }
+      }
+
+      return success();
+    }
+    /// Verify the type attribute of the function for derived op-specific
+    /// invariants.
+    ::mlir::LogicalResult verifyType() {
+      return success();
+    }
+    static ::mlir::LogicalResult verifyTrait(::mlir::Operation *op) {
+      return function_interface_impl::verifyTrait(cast<ConcreteOp>(op));
+    }
+
+    //===------------------------------------------------------------------===//
+    // Builders
+    //===------------------------------------------------------------------===//
+
+    /// Build the function with the given name, attributes, and type. This
+    /// builder also inserts an entry block into the function body with the
+    /// given argument types.
+    static void buildWithEntryBlock(
+        OpBuilder &builder, OperationState &state, StringRef name, Type type,
+        ArrayRef<NamedAttribute> attrs, TypeRange inputTypes) {
+      state.addAttribute(SymbolTable::getSymbolAttrName(),
+                        builder.getStringAttr(name));
+      state.addAttribute(ConcreteOp::getFunctionTypeAttrName(state.name),
+                        TypeAttr::get(type));
+      state.attributes.append(attrs.begin(), attrs.end());
+
+      // Add the function body.
+      Region *bodyRegion = state.addRegion();
+      Block *body = new Block();
+      bodyRegion->push_back(body);
+      for (Type input : inputTypes)
+        body->addArgument(input, state.location);
+    }
+  
+
+    /// Block list iterator types.
+    using BlockListType = Region::BlockListType;
+    using iterator = BlockListType::iterator;
+    using reverse_iterator = BlockListType::reverse_iterator;
+
+    /// Block argument iterator types.
+    using BlockArgListType = Region::BlockArgListType;
+    using args_iterator = BlockArgListType::iterator;
+
+    //===------------------------------------------------------------------===//
+    // Body Handling
+    //===------------------------------------------------------------------===//
+
+    /// Returns true if this function is external, i.e. it has no body.
+    bool isExternal() { return empty(); }
+
+    /// Return the region containing the body of this function.
+    Region &getFunctionBody() { return (*static_cast<ConcreteOp *>(this))->getRegion(0); }
+
+    /// Delete all blocks from this function.
+    void eraseBody() {
+      getFunctionBody().dropAllReferences();
+      getFunctionBody().getBlocks().clear();
+    }
+
+    /// Return the list of blocks within the function body.
+    BlockListType &getBlocks() { return getFunctionBody().getBlocks(); }
+
+    iterator begin() { return getFunctionBody().begin(); }
+    iterator end() { return getFunctionBody().end(); }
+    reverse_iterator rbegin() { return getFunctionBody().rbegin(); }
+    reverse_iterator rend() { return getFunctionBody().rend(); }
+
+    /// Returns true if this function has no blocks within the body.
+    bool empty() { return getFunctionBody().empty(); }
+
+    /// Push a new block to the back of the body region.
+    void push_back(Block *block) { getFunctionBody().push_back(block); }
+
+    /// Push a new block to the front of the body region.
+    void push_front(Block *block) { getFunctionBody().push_front(block); }
+
+    /// Return the last block in the body region.
+    Block &back() { return getFunctionBody().back(); }
+
+    /// Return the first block in the body region.
+    Block &front() { return getFunctionBody().front(); }
+
+    /// Add an entry block to an empty function, and set up the block arguments
+    /// to match the signature of the function. The newly inserted entry block
+    /// is returned.
+    Block *addEntryBlock() {
+      assert(empty() && "function already has an entry block");
+      Block *entry = new Block();
+      push_back(entry);
+
+      // FIXME: Allow for passing in locations for these arguments instead of using
+      // the operations location.
+      ArrayRef<Type> inputTypes = (*static_cast<ConcreteOp *>(this)).getArgumentTypes();
+      SmallVector<Location> locations(inputTypes.size(),
+                                      (*static_cast<ConcreteOp *>(this)).getOperation()->getLoc());
+      entry->addArguments(inputTypes, locations);
+      return entry;
+    }
+
+    /// Add a normal block to the end of the function's block list. The function
+    /// should at least already have an entry block.
+    Block *addBlock() {
+      assert(!empty() && "function should at least have an entry block");
+      push_back(new Block());
+      return &back();
+    }
+
+    //===------------------------------------------------------------------===//
+    // Type Attribute Handling
+    //===------------------------------------------------------------------===//
+
+    /// Change the type of this function in place. This is an extremely dangerous
+    /// operation and it is up to the caller to ensure that this is legal for
+    /// this function, and to restore invariants:
+    ///  - the entry block args must be updated to match the function params.
+    ///  - the argument/result attributes may need an update: if the new type
+    ///    has less parameters we drop the extra attributes, if there are more
+    ///    parameters they won't have any attributes.
+    void setType(Type newType) {
+      function_interface_impl::setFunctionType(this->getOperation(), newType);
+    }
+
+    //===------------------------------------------------------------------===//
+    // Argument and Result Handling
+    //===------------------------------------------------------------------===//
+
+    /// Returns the number of function arguments.
+    unsigned getNumArguments() { return (*static_cast<ConcreteOp *>(this)).getArgumentTypes().size(); }
+
+    /// Returns the number of function results.
+    unsigned getNumResults() { return (*static_cast<ConcreteOp *>(this)).getResultTypes().size(); }
+
+    /// Returns the entry block function argument at the given index.
+    BlockArgument getArgument(unsigned idx) {
+      return getFunctionBody().getArgument(idx);
+    }
+
+    /// Support argument iteration.
+    args_iterator args_begin() { return getFunctionBody().args_begin(); }
+    args_iterator args_end() { return getFunctionBody().args_end(); }
+    BlockArgListType getArguments() { return getFunctionBody().getArguments(); }
+
+    /// Insert a single argument of type `argType` with attributes `argAttrs` and
+    /// location `argLoc` at `argIndex`.
+    void insertArgument(unsigned argIndex, Type argType, DictionaryAttr argAttrs,
+                        Location argLoc) {
+      insertArguments({argIndex}, {argType}, {argAttrs}, {argLoc});
+    }
+
+    /// Inserts arguments with the listed types, attributes, and locations at the
+    /// listed indices. `argIndices` must be sorted. Arguments are inserted in the
+    /// order they are listed, such that arguments with identical index will
+    /// appear in the same order that they were listed here.
+    void insertArguments(ArrayRef<unsigned> argIndices, TypeRange argTypes,
+                        ArrayRef<DictionaryAttr> argAttrs,
+                        ArrayRef<Location> argLocs) {
+      unsigned originalNumArgs = (*static_cast<ConcreteOp *>(this)).getNumArguments();
+      Type newType = (*static_cast<ConcreteOp *>(this)).getTypeWithArgsAndResults(
+          argIndices, argTypes, /*resultIndices=*/{}, /*resultTypes=*/{});
+      function_interface_impl::insertFunctionArguments(
+          this->getOperation(), argIndices, argTypes, argAttrs, argLocs,
+          originalNumArgs, newType);
+    }
+
+    /// Insert a single result of type `resultType` at `resultIndex`.
+    void insertResult(unsigned resultIndex, Type resultType,
+                      DictionaryAttr resultAttrs) {
+      insertResults({resultIndex}, {resultType}, {resultAttrs});
+    }
+
+    /// Inserts results with the listed types at the listed indices.
+    /// `resultIndices` must be sorted. Results are inserted in the order they are
+    /// listed, such that results with identical index will appear in the same
+    /// order that they were listed here.
+    void insertResults(ArrayRef<unsigned> resultIndices, TypeRange resultTypes,
+                      ArrayRef<DictionaryAttr> resultAttrs) {
+      unsigned originalNumResults = (*static_cast<ConcreteOp *>(this)).getNumResults();
+      Type newType = (*static_cast<ConcreteOp *>(this)).getTypeWithArgsAndResults(
+        /*argIndices=*/{}, /*argTypes=*/{}, resultIndices, resultTypes);
+      function_interface_impl::insertFunctionResults(
+          this->getOperation(), resultIndices, resultTypes, resultAttrs,
+          originalNumResults, newType);
+    }
+
+    /// Erase a single argument at `argIndex`.
+    void eraseArgument(unsigned argIndex) {
+      BitVector argsToErase((*static_cast<ConcreteOp *>(this)).getNumArguments());
+      argsToErase.set(argIndex);
+      eraseArguments(argsToErase);
+    }
+
+    /// Erases the arguments listed in `argIndices`.
+    void eraseArguments(const BitVector &argIndices) {
+      Type newType = (*static_cast<ConcreteOp *>(this)).getTypeWithoutArgs(argIndices);
+      function_interface_impl::eraseFunctionArguments(
+        this->getOperation(), argIndices, newType);
+    }
+
+    /// Erase a single result at `resultIndex`.
+    void eraseResult(unsigned resultIndex) {
+      BitVector resultsToErase((*static_cast<ConcreteOp *>(this)).getNumResults());
+      resultsToErase.set(resultIndex);
+      eraseResults(resultsToErase);
+    }
+
+    /// Erases the results listed in `resultIndices`.
+    void eraseResults(const BitVector &resultIndices) {
+      Type newType = (*static_cast<ConcreteOp *>(this)).getTypeWithoutResults(resultIndices);
+      function_interface_impl::eraseFunctionResults(
+          this->getOperation(), resultIndices, newType);
+    }
+
+    /// Return the type of this function with the specified arguments and
+    /// results inserted. This is used to update the function's signature in
+    /// the `insertArguments` and `insertResults` methods. The arrays must be
+    /// sorted by increasing index.
+    Type getTypeWithArgsAndResults(
+      ArrayRef<unsigned> argIndices, TypeRange argTypes,
+      ArrayRef<unsigned> resultIndices, TypeRange resultTypes) {
+      SmallVector<Type> argStorage, resultStorage;
+      TypeRange newArgTypes = function_interface_impl::insertTypesInto(
+          (*static_cast<ConcreteOp *>(this)).getArgumentTypes(), argIndices, argTypes, argStorage);
+      TypeRange newResultTypes = function_interface_impl::insertTypesInto(
+          (*static_cast<ConcreteOp *>(this)).getResultTypes(), resultIndices, resultTypes, resultStorage);
+      return (*static_cast<ConcreteOp *>(this)).cloneTypeWith(newArgTypes, newResultTypes);
+    }
+
+    /// Return the type of this function without the specified arguments and
+    /// results. This is used to update the function's signature in the
+    /// `eraseArguments` and `eraseResults` methods.
+    Type getTypeWithoutArgsAndResults(
+      const BitVector &argIndices, const BitVector &resultIndices) {
+      SmallVector<Type> argStorage, resultStorage;
+      TypeRange newArgTypes = function_interface_impl::filterTypesOut(
+          (*static_cast<ConcreteOp *>(this)).getArgumentTypes(), argIndices, argStorage);
+      TypeRange newResultTypes = function_interface_impl::filterTypesOut(
+          (*static_cast<ConcreteOp *>(this)).getResultTypes(), resultIndices, resultStorage);
+      return (*static_cast<ConcreteOp *>(this)).cloneTypeWith(newArgTypes, newResultTypes);
+    }
+    Type getTypeWithoutArgs(const BitVector &argIndices) {
+      SmallVector<Type> argStorage;
+      TypeRange newArgTypes = function_interface_impl::filterTypesOut(
+          (*static_cast<ConcreteOp *>(this)).getArgumentTypes(), argIndices, argStorage);
+      return (*static_cast<ConcreteOp *>(this)).cloneTypeWith(newArgTypes, (*static_cast<ConcreteOp *>(this)).getResultTypes());
+    }
+    Type getTypeWithoutResults(const BitVector &resultIndices) {
+      SmallVector<Type> resultStorage;
+      TypeRange newResultTypes = function_interface_impl::filterTypesOut(
+          (*static_cast<ConcreteOp *>(this)).getResultTypes(), resultIndices, resultStorage);
+      return (*static_cast<ConcreteOp *>(this)).cloneTypeWith((*static_cast<ConcreteOp *>(this)).getArgumentTypes(), newResultTypes);
+    }
+
+    //===------------------------------------------------------------------===//
+    // Argument Attributes
+    //===------------------------------------------------------------------===//
+
+    /// Return all of the attributes for the argument at 'index'.
+    ArrayRef<NamedAttribute> getArgAttrs(unsigned index) {
+      return function_interface_impl::getArgAttrs(this->getOperation(), index);
+    }
+
+    /// Return an ArrayAttr containing all argument attribute dictionaries of
+    /// this function, or nullptr if no arguments have attributes.
+    ArrayAttr getAllArgAttrs() { return (*static_cast<ConcreteOp *>(this)).getArgAttrsAttr(); }
+
+    /// Return all argument attributes of this function.
+    void getAllArgAttrs(SmallVectorImpl<DictionaryAttr> &result) {
+      if (ArrayAttr argAttrs = getAllArgAttrs()) {
+        auto argAttrRange = argAttrs.template getAsRange<DictionaryAttr>();
+        result.append(argAttrRange.begin(), argAttrRange.end());
+      } else {
+        result.append((*static_cast<ConcreteOp *>(this)).getNumArguments(),
+                      DictionaryAttr::get(this->getOperation()->getContext()));
+      }
+    }
+
+    /// Return the specified attribute, if present, for the argument at 'index',
+    /// null otherwise.
+    Attribute getArgAttr(unsigned index, StringAttr name) {
+      auto argDict = getArgAttrDict(index);
+      return argDict ? argDict.get(name) : nullptr;
+    }
+    Attribute getArgAttr(unsigned index, StringRef name) {
+      auto argDict = getArgAttrDict(index);
+      return argDict ? argDict.get(name) : nullptr;
+    }
+
+    template <typename AttrClass>
+    AttrClass getArgAttrOfType(unsigned index, StringAttr name) {
+      return getArgAttr(index, name).template dyn_cast_or_null<AttrClass>();
+    }
+    template <typename AttrClass>
+    AttrClass getArgAttrOfType(unsigned index, StringRef name) {
+      return getArgAttr(index, name).template dyn_cast_or_null<AttrClass>();
+    }
+
+    /// Set the attributes held by the argument at 'index'.
+    void setArgAttrs(unsigned index, ArrayRef<NamedAttribute> attributes) {
+      function_interface_impl::setArgAttrs((*static_cast<ConcreteOp *>(this)), index, attributes);
+    }
+
+    /// Set the attributes held by the argument at 'index'. `attributes` may be
+    /// null, in which case any existing argument attributes are removed.
+    void setArgAttrs(unsigned index, DictionaryAttr attributes) {
+      function_interface_impl::setArgAttrs((*static_cast<ConcreteOp *>(this)), index, attributes);
+    }
+    void setAllArgAttrs(ArrayRef<DictionaryAttr> attributes) {
+      assert(attributes.size() == (*static_cast<ConcreteOp *>(this)).getNumArguments());
+      function_interface_impl::setAllArgAttrDicts(this->getOperation(), attributes);
+    }
+    void setAllArgAttrs(ArrayRef<Attribute> attributes) {
+      assert(attributes.size() == (*static_cast<ConcreteOp *>(this)).getNumArguments());
+      function_interface_impl::setAllArgAttrDicts(this->getOperation(), attributes);
+    }
+    void setAllArgAttrs(ArrayAttr attributes) {
+      assert(attributes.size() == (*static_cast<ConcreteOp *>(this)).getNumArguments());
+      (*static_cast<ConcreteOp *>(this)).setArgAttrsAttr(attributes);
+    }
+
+    /// If the an attribute exists with the specified name, change it to the new
+    /// value. Otherwise, add a new attribute with the specified name/value.
+    void setArgAttr(unsigned index, StringAttr name, Attribute value) {
+      function_interface_impl::setArgAttr((*static_cast<ConcreteOp *>(this)), index, name, value);
+    }
+    void setArgAttr(unsigned index, StringRef name, Attribute value) {
+      setArgAttr(index,
+                 StringAttr::get(this->getOperation()->getContext(), name),
+                 value);
+    }
+
+    /// Remove the attribute 'name' from the argument at 'index'. Return the
+    /// attribute that was erased, or nullptr if there was no attribute with
+    /// such name.
+    Attribute removeArgAttr(unsigned index, StringAttr name) {
+      return function_interface_impl::removeArgAttr((*static_cast<ConcreteOp *>(this)), index, name);
+    }
+    Attribute removeArgAttr(unsigned index, StringRef name) {
+      return removeArgAttr(
+          index, StringAttr::get(this->getOperation()->getContext(), name));
+    }
+
+    //===------------------------------------------------------------------===//
+    // Result Attributes
+    //===------------------------------------------------------------------===//
+
+    /// Return all of the attributes for the result at 'index'.
+    ArrayRef<NamedAttribute> getResultAttrs(unsigned index) {
+      return function_interface_impl::getResultAttrs(this->getOperation(), index);
+    }
+
+    /// Return an ArrayAttr containing all result attribute dictionaries of this
+    /// function, or nullptr if no result have attributes.
+    ArrayAttr getAllResultAttrs() { return (*static_cast<ConcreteOp *>(this)).getResAttrsAttr(); }
+
+    /// Return all result attributes of this function.
+    void getAllResultAttrs(SmallVectorImpl<DictionaryAttr> &result) {
+      if (ArrayAttr argAttrs = getAllResultAttrs()) {
+        auto argAttrRange = argAttrs.template getAsRange<DictionaryAttr>();
+        result.append(argAttrRange.begin(), argAttrRange.end());
+      } else {
+        result.append((*static_cast<ConcreteOp *>(this)).getNumResults(),
+                      DictionaryAttr::get(this->getOperation()->getContext()));
+      }
+    }
+
+    /// Return the specified attribute, if present, for the result at 'index',
+    /// null otherwise.
+    Attribute getResultAttr(unsigned index, StringAttr name) {
+      auto argDict = getResultAttrDict(index);
+      return argDict ? argDict.get(name) : nullptr;
+    }
+    Attribute getResultAttr(unsigned index, StringRef name) {
+      auto argDict = getResultAttrDict(index);
+      return argDict ? argDict.get(name) : nullptr;
+    }
+
+    template <typename AttrClass>
+    AttrClass getResultAttrOfType(unsigned index, StringAttr name) {
+      return getResultAttr(index, name).template dyn_cast_or_null<AttrClass>();
+    }
+    template <typename AttrClass>
+    AttrClass getResultAttrOfType(unsigned index, StringRef name) {
+      return getResultAttr(index, name).template dyn_cast_or_null<AttrClass>();
+    }
+
+    /// Set the attributes held by the result at 'index'.
+    void setResultAttrs(unsigned index, ArrayRef<NamedAttribute> attributes) {
+      function_interface_impl::setResultAttrs((*static_cast<ConcreteOp *>(this)), index, attributes);
+    }
+
+    /// Set the attributes held by the result at 'index'. `attributes` may be
+    /// null, in which case any existing argument attributes are removed.
+    void setResultAttrs(unsigned index, DictionaryAttr attributes) {
+      function_interface_impl::setResultAttrs((*static_cast<ConcreteOp *>(this)), index, attributes);
+    }
+    void setAllResultAttrs(ArrayRef<DictionaryAttr> attributes) {
+      assert(attributes.size() == (*static_cast<ConcreteOp *>(this)).getNumResults());
+      function_interface_impl::setAllResultAttrDicts(
+        this->getOperation(), attributes);
+    }
+    void setAllResultAttrs(ArrayRef<Attribute> attributes) {
+      assert(attributes.size() == (*static_cast<ConcreteOp *>(this)).getNumResults());
+      function_interface_impl::setAllResultAttrDicts(
+        this->getOperation(), attributes);
+    }
+    void setAllResultAttrs(ArrayAttr attributes) {
+      assert(attributes.size() == (*static_cast<ConcreteOp *>(this)).getNumResults());
+      (*static_cast<ConcreteOp *>(this)).setResAttrsAttr(attributes);
+    }
+
+    /// If the an attribute exists with the specified name, change it to the new
+    /// value. Otherwise, add a new attribute with the specified name/value.
+    void setResultAttr(unsigned index, StringAttr name, Attribute value) {
+      function_interface_impl::setResultAttr((*static_cast<ConcreteOp *>(this)), index, name, value);
+    }
+    void setResultAttr(unsigned index, StringRef name, Attribute value) {
+      setResultAttr(index,
+                    StringAttr::get(this->getOperation()->getContext(), name),
+                    value);
+    }
+
+    /// Remove the attribute 'name' from the result at 'index'. Return the
+    /// attribute that was erased, or nullptr if there was no attribute with
+    /// such name.
+    Attribute removeResultAttr(unsigned index, StringAttr name) {
+      return function_interface_impl::removeResultAttr((*static_cast<ConcreteOp *>(this)), index, name);
+    }
+
+    /// Returns the dictionary attribute corresponding to the argument at
+    /// 'index'. If there are no argument attributes at 'index', a null
+    /// attribute is returned.
+    DictionaryAttr getArgAttrDict(unsigned index) {
+      assert(index < (*static_cast<ConcreteOp *>(this)).getNumArguments() && "invalid argument number");
+      return function_interface_impl::getArgAttrDict(this->getOperation(), index);
+    }
+
+    /// Returns the dictionary attribute corresponding to the result at 'index'.
+    /// If there are no result attributes at 'index', a null attribute is
+    /// returned.
+    DictionaryAttr getResultAttrDict(unsigned index) {
+      assert(index < (*static_cast<ConcreteOp *>(this)).getNumResults() && "invalid result number");
+      return function_interface_impl::getResultAttrDict(this->getOperation(), index);
+    }
+  
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::Type detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::getFunctionType(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getFunctionType();
+}
+template<typename ConcreteOp>
+void detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::setFunctionTypeAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::TypeAttr type) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).setFunctionTypeAttr(type);
+}
+template<typename ConcreteOp>
+::mlir::ArrayAttr detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::getArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getArgAttrsAttr();
+}
+template<typename ConcreteOp>
+::mlir::ArrayAttr detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::getResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getResAttrsAttr();
+}
+template<typename ConcreteOp>
+void detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::setArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::ArrayAttr attrs) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).setArgAttrsAttr(attrs);
+}
+template<typename ConcreteOp>
+void detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::setResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::ArrayAttr attrs) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).setResAttrsAttr(attrs);
+}
+template<typename ConcreteOp>
+::mlir::Attribute detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::removeArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).removeArgAttrsAttr();
+}
+template<typename ConcreteOp>
+::mlir::Attribute detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::removeResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).removeResAttrsAttr();
+}
+template<typename ConcreteOp>
+::llvm::ArrayRef<::mlir::Type> detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::getArgumentTypes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getArgumentTypes();
+}
+template<typename ConcreteOp>
+::llvm::ArrayRef<::mlir::Type> detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::getResultTypes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getResultTypes();
+}
+template<typename ConcreteOp>
+::mlir::Type detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::cloneTypeWith(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::TypeRange inputs, ::mlir::TypeRange results) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).cloneTypeWith(inputs, results);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::verifyBody(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).verifyBody();
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::FunctionOpInterfaceInterfaceTraits::Model<ConcreteOp>::verifyType(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).verifyType();
+}
+template<typename ConcreteOp>
+::mlir::Type detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getFunctionType(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getFunctionType(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+void detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::setFunctionTypeAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::TypeAttr type) {
+  return static_cast<const ConcreteOp *>(impl)->setFunctionTypeAttr(tablegen_opaque_val, type);
+}
+template<typename ConcreteOp>
+::mlir::ArrayAttr detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getArgAttrsAttr(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::mlir::ArrayAttr detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getResAttrsAttr(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+void detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::setArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::ArrayAttr attrs) {
+  return static_cast<const ConcreteOp *>(impl)->setArgAttrsAttr(tablegen_opaque_val, attrs);
+}
+template<typename ConcreteOp>
+void detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::setResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::ArrayAttr attrs) {
+  return static_cast<const ConcreteOp *>(impl)->setResAttrsAttr(tablegen_opaque_val, attrs);
+}
+template<typename ConcreteOp>
+::mlir::Attribute detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::removeArgAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->removeArgAttrsAttr(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::mlir::Attribute detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::removeResAttrsAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->removeResAttrsAttr(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::llvm::ArrayRef<::mlir::Type> detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getArgumentTypes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getArgumentTypes(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::llvm::ArrayRef<::mlir::Type> detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getResultTypes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getResultTypes(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::mlir::Type detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::cloneTypeWith(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::TypeRange inputs, ::mlir::TypeRange results) {
+  return static_cast<const ConcreteOp *>(impl)->cloneTypeWith(tablegen_opaque_val, inputs, results);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::verifyBody(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->verifyBody(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::FunctionOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::verifyType(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->verifyType(tablegen_opaque_val);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::mlir::Type detail::FunctionOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::cloneTypeWith(::mlir::Operation *tablegen_opaque_val, ::mlir::TypeRange inputs, ::mlir::TypeRange results) const {
+return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getFunctionType().clone(inputs, results);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::mlir::LogicalResult detail::FunctionOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::verifyBody(::mlir::Operation *tablegen_opaque_val) const {
+if ((llvm::cast<ConcreteOp>(tablegen_opaque_val)).isExternal())
+        return success();
+      ArrayRef<Type> fnInputTypes = (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getArgumentTypes();
+      // NOTE: This should just be (llvm::cast<ConcreteOp>(tablegen_opaque_val)).front() but access generically
+      // because the interface methods defined here may be shadowed in
+      // arbitrary ways. https://github.com/llvm/llvm-project/issues/54807
+      Block &entryBlock = (llvm::cast<ConcreteOp>(tablegen_opaque_val))->getRegion(0).front();
+
+      unsigned numArguments = fnInputTypes.size();
+      if (entryBlock.getNumArguments() != numArguments)
+        return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).emitOpError("entry block must have ")
+              << numArguments << " arguments to match function signature";
+
+      for (unsigned i = 0, e = fnInputTypes.size(); i != e; ++i) {
+        Type argType = entryBlock.getArgument(i).getType();
+        if (fnInputTypes[i] != argType) {
+          return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).emitOpError("type of entry block argument #")
+                << i << '(' << argType
+                << ") must match the type of the corresponding argument in "
+                << "function signature(" << fnInputTypes[i] << ')';
+        }
+      }
+
+      return success();
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::mlir::LogicalResult detail::FunctionOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::verifyType(::mlir::Operation *tablegen_opaque_val) const {
+return success();
+}
+} // namespace mlir

--- a/mlir/include/mlir/IR/OpAsmInterface.h.inc
+++ b/mlir/include/mlir/IR/OpAsmInterface.h.inc
@@ -1,0 +1,237 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class OpAsmOpInterface;
+namespace detail {
+struct OpAsmOpInterfaceInterfaceTraits {
+  struct Concept {
+    void (*getAsmResultNames)(const Concept *impl, ::mlir::Operation *, ::mlir::OpAsmSetValueNameFn);
+    void (*getAsmBlockArgumentNames)(const Concept *impl, ::mlir::Operation *, ::mlir::Region&, ::mlir::OpAsmSetValueNameFn);
+    void (*getAsmBlockNames)(const Concept *impl, ::mlir::Operation *, ::mlir::OpAsmSetBlockNameFn);
+    ::llvm::StringRef (*getDefaultDialect)();
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::OpAsmOpInterface;
+    Model() : Concept{getAsmResultNames, getAsmBlockArgumentNames, getAsmBlockNames, getDefaultDialect} {}
+
+    static inline void getAsmResultNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetValueNameFn setNameFn);
+    static inline void getAsmBlockArgumentNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Region& region, ::mlir::OpAsmSetValueNameFn setNameFn);
+    static inline void getAsmBlockNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetBlockNameFn setNameFn);
+    static inline ::llvm::StringRef getDefaultDialect();
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::OpAsmOpInterface;
+    FallbackModel() : Concept{getAsmResultNames, getAsmBlockArgumentNames, getAsmBlockNames, getDefaultDialect} {}
+
+    static inline void getAsmResultNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetValueNameFn setNameFn);
+    static inline void getAsmBlockArgumentNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Region& region, ::mlir::OpAsmSetValueNameFn setNameFn);
+    static inline void getAsmBlockNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetBlockNameFn setNameFn);
+    static inline ::llvm::StringRef getDefaultDialect();
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+    void getAsmResultNames(::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetValueNameFn setNameFn) const;
+    void getAsmBlockArgumentNames(::mlir::Operation *tablegen_opaque_val, ::mlir::Region&region, ::mlir::OpAsmSetValueNameFn setNameFn) const;
+    void getAsmBlockNames(::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetBlockNameFn setNameFn) const;
+    static ::llvm::StringRef getDefaultDialect();
+  };
+};template <typename ConcreteOp>
+struct OpAsmOpInterfaceTrait;
+
+} // namespace detail
+class OpAsmOpInterface : public ::mlir::OpInterface<OpAsmOpInterface, detail::OpAsmOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<OpAsmOpInterface, detail::OpAsmOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::OpAsmOpInterfaceTrait<ConcreteOp> {};
+  /// Get a special name to use when printing the results of this operation.
+  /// The given callback is invoked with a specific result value that starts a
+  /// result "pack", and the name to give this result pack. To signal that a
+  /// result pack should use the default naming scheme, a None can be passed
+  /// in instead of the name.
+  /// 
+  /// For example, if you have an operation that has four results and you want
+  /// to split these into three distinct groups you could do the following:
+  /// 
+  /// ```c++
+  ///   setNameFn(getResult(0), "first_result");
+  ///   setNameFn(getResult(1), "middle_results");
+  ///   setNameFn(getResult(3), ""); // use the default numbering.
+  /// ```
+  /// 
+  /// This would print the operation as follows:
+  /// 
+  /// ```mlir
+  ///   %first_result, %middle_results:2, %0 = "my.op" ...
+  /// ```
+  void getAsmResultNames(::mlir::OpAsmSetValueNameFn setNameFn);
+  /// Get a special name to use when printing the block arguments for a region
+  /// immediately nested under this operation.
+  void getAsmBlockArgumentNames(::mlir::Region& region, ::mlir::OpAsmSetValueNameFn setNameFn);
+  /// Get the name to use for a given block inside a region attached to this
+  /// operation.
+  /// 
+  /// For example if this operation has multiple blocks:
+  /// 
+  /// ```mlir
+  ///   some.op() ({
+  ///     ^bb0:
+  ///       ...
+  ///     ^bb1:
+  ///       ...
+  ///   })
+  /// ```
+  /// 
+  /// the method will be invoked on each of the blocks allowing the op to
+  /// print:
+  /// 
+  /// ```mlir
+  ///   some.op() ({
+  ///     ^custom_foo_name:
+  ///       ...
+  ///     ^custom_bar_name:
+  ///       ...
+  ///   })
+  /// ```
+  void getAsmBlockNames(::mlir::OpAsmSetBlockNameFn setNameFn);
+  /// Return the default dialect used when printing/parsing operations in
+  /// regions nested under this operation. This allows for eliding the dialect
+  /// prefix from the operation name, for example it would be possible to omit
+  /// the `spirv.` prefix from all operations within a SpirV module if this method
+  /// returned `spv`. The default implementation returns an empty string which
+  /// is ignored.
+  ::llvm::StringRef getDefaultDialect();
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct OpAsmOpInterfaceTrait : public ::mlir::OpInterface<OpAsmOpInterface, detail::OpAsmOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+    /// Get a special name to use when printing the results of this operation.
+    /// The given callback is invoked with a specific result value that starts a
+    /// result "pack", and the name to give this result pack. To signal that a
+    /// result pack should use the default naming scheme, a None can be passed
+    /// in instead of the name.
+    /// 
+    /// For example, if you have an operation that has four results and you want
+    /// to split these into three distinct groups you could do the following:
+    /// 
+    /// ```c++
+    ///   setNameFn(getResult(0), "first_result");
+    ///   setNameFn(getResult(1), "middle_results");
+    ///   setNameFn(getResult(3), ""); // use the default numbering.
+    /// ```
+    /// 
+    /// This would print the operation as follows:
+    /// 
+    /// ```mlir
+    ///   %first_result, %middle_results:2, %0 = "my.op" ...
+    /// ```
+    void getAsmResultNames(::mlir::OpAsmSetValueNameFn setNameFn) {
+      return;
+    }
+    /// Get a special name to use when printing the block arguments for a region
+    /// immediately nested under this operation.
+    void getAsmBlockArgumentNames(::mlir::Region& region, ::mlir::OpAsmSetValueNameFn setNameFn) {
+      return;
+    }
+    /// Get the name to use for a given block inside a region attached to this
+    /// operation.
+    /// 
+    /// For example if this operation has multiple blocks:
+    /// 
+    /// ```mlir
+    ///   some.op() ({
+    ///     ^bb0:
+    ///       ...
+    ///     ^bb1:
+    ///       ...
+    ///   })
+    /// ```
+    /// 
+    /// the method will be invoked on each of the blocks allowing the op to
+    /// print:
+    /// 
+    /// ```mlir
+    ///   some.op() ({
+    ///     ^custom_foo_name:
+    ///       ...
+    ///     ^custom_bar_name:
+    ///       ...
+    ///   })
+    /// ```
+    void getAsmBlockNames(::mlir::OpAsmSetBlockNameFn setNameFn) {
+      ;
+    }
+    /// Return the default dialect used when printing/parsing operations in
+    /// regions nested under this operation. This allows for eliding the dialect
+    /// prefix from the operation name, for example it would be possible to omit
+    /// the `spirv.` prefix from all operations within a SpirV module if this method
+    /// returned `spv`. The default implementation returns an empty string which
+    /// is ignored.
+    static ::llvm::StringRef getDefaultDialect() {
+      return "";
+    }
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::Model<ConcreteOp>::getAsmResultNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetValueNameFn setNameFn) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getAsmResultNames(setNameFn);
+}
+template<typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::Model<ConcreteOp>::getAsmBlockArgumentNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Region& region, ::mlir::OpAsmSetValueNameFn setNameFn) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getAsmBlockArgumentNames(region, setNameFn);
+}
+template<typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::Model<ConcreteOp>::getAsmBlockNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetBlockNameFn setNameFn) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getAsmBlockNames(setNameFn);
+}
+template<typename ConcreteOp>
+::llvm::StringRef detail::OpAsmOpInterfaceInterfaceTraits::Model<ConcreteOp>::getDefaultDialect() {
+  return ConcreteOp::getDefaultDialect();
+}
+template<typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getAsmResultNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetValueNameFn setNameFn) {
+  return static_cast<const ConcreteOp *>(impl)->getAsmResultNames(tablegen_opaque_val, setNameFn);
+}
+template<typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getAsmBlockArgumentNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Region& region, ::mlir::OpAsmSetValueNameFn setNameFn) {
+  return static_cast<const ConcreteOp *>(impl)->getAsmBlockArgumentNames(tablegen_opaque_val, region, setNameFn);
+}
+template<typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getAsmBlockNames(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetBlockNameFn setNameFn) {
+  return static_cast<const ConcreteOp *>(impl)->getAsmBlockNames(tablegen_opaque_val, setNameFn);
+}
+template<typename ConcreteOp>
+::llvm::StringRef detail::OpAsmOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getDefaultDialect() {
+  return ConcreteOp::getDefaultDialect();
+}
+template<typename ConcreteModel, typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getAsmResultNames(::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetValueNameFn setNameFn) const {
+return;
+}
+template<typename ConcreteModel, typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getAsmBlockArgumentNames(::mlir::Operation *tablegen_opaque_val, ::mlir::Region&region, ::mlir::OpAsmSetValueNameFn setNameFn) const {
+return;
+}
+template<typename ConcreteModel, typename ConcreteOp>
+void detail::OpAsmOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getAsmBlockNames(::mlir::Operation *tablegen_opaque_val, ::mlir::OpAsmSetBlockNameFn setNameFn) const {
+;
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::llvm::StringRef detail::OpAsmOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getDefaultDialect() {
+return "";
+}
+} // namespace mlir

--- a/mlir/include/mlir/IR/RegionKindInterface.h.inc
+++ b/mlir/include/mlir/IR/RegionKindInterface.h.inc
@@ -1,0 +1,77 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class RegionKindInterface;
+namespace detail {
+struct RegionKindInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::RegionKind (*getRegionKind)(unsigned);
+    bool (*hasSSADominance)(unsigned);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::RegionKindInterface;
+    Model() : Concept{getRegionKind, hasSSADominance} {}
+
+    static inline ::mlir::RegionKind getRegionKind(unsigned index);
+    static inline bool hasSSADominance(unsigned index);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::RegionKindInterface;
+    FallbackModel() : Concept{getRegionKind, hasSSADominance} {}
+
+    static inline ::mlir::RegionKind getRegionKind(unsigned index);
+    static inline bool hasSSADominance(unsigned index);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+  };
+};template <typename ConcreteOp>
+struct RegionKindInterfaceTrait;
+
+} // namespace detail
+class RegionKindInterface : public ::mlir::OpInterface<RegionKindInterface, detail::RegionKindInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<RegionKindInterface, detail::RegionKindInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::RegionKindInterfaceTrait<ConcreteOp> {};
+  /// Return the kind of the region with the given index inside this operation.
+  ::mlir::RegionKind getRegionKind(unsigned index);
+  /// Return true if the kind of the given region requires the SSA-Dominance property
+  bool hasSSADominance(unsigned index);
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct RegionKindInterfaceTrait : public ::mlir::OpInterface<RegionKindInterface, detail::RegionKindInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::RegionKind detail::RegionKindInterfaceInterfaceTraits::Model<ConcreteOp>::getRegionKind(unsigned index) {
+  return ConcreteOp::getRegionKind(index);
+}
+template<typename ConcreteOp>
+bool detail::RegionKindInterfaceInterfaceTraits::Model<ConcreteOp>::hasSSADominance(unsigned index) {
+  return getRegionKind(index) == ::mlir::RegionKind::SSACFG;
+}
+template<typename ConcreteOp>
+::mlir::RegionKind detail::RegionKindInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getRegionKind(unsigned index) {
+  return ConcreteOp::getRegionKind(index);
+}
+template<typename ConcreteOp>
+bool detail::RegionKindInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::hasSSADominance(unsigned index) {
+  return ConcreteOp::hasSSADominance(index);
+}
+} // namespace mlir

--- a/mlir/include/mlir/IR/SubElementAttrInterfaces.h.inc
+++ b/mlir/include/mlir/IR/SubElementAttrInterfaces.h.inc
@@ -1,0 +1,173 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class SubElementAttrInterface;
+namespace detail {
+struct SubElementAttrInterfaceInterfaceTraits {
+  struct Concept {
+    void (*walkImmediateSubElements)(const Concept *impl, ::mlir::Attribute , llvm::function_ref<void(mlir::Attribute)>, llvm::function_ref<void(mlir::Type)>);
+    ::mlir::Attribute (*replaceImmediateSubElements)(const Concept *impl, ::mlir::Attribute , ::llvm::ArrayRef<::mlir::Attribute>, ::llvm::ArrayRef<::mlir::Type>);
+  };
+  template<typename ConcreteAttr>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::SubElementAttrInterface;
+    Model() : Concept{walkImmediateSubElements, replaceImmediateSubElements} {}
+
+    static inline void walkImmediateSubElements(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn);
+    static inline ::mlir::Attribute replaceImmediateSubElements(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes);
+  };
+  template<typename ConcreteAttr>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::SubElementAttrInterface;
+    FallbackModel() : Concept{walkImmediateSubElements, replaceImmediateSubElements} {}
+
+    static inline void walkImmediateSubElements(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn);
+    static inline ::mlir::Attribute replaceImmediateSubElements(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes);
+  };
+  template<typename ConcreteModel, typename ConcreteAttr>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteAttr;
+    void walkImmediateSubElements(::mlir::Attribute tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) const;
+    ::mlir::Attribute replaceImmediateSubElements(::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) const;
+  };
+};template <typename ConcreteAttr>
+struct SubElementAttrInterfaceTrait;
+
+} // namespace detail
+class SubElementAttrInterface : public ::mlir::AttributeInterface<SubElementAttrInterface, detail::SubElementAttrInterfaceInterfaceTraits> {
+public:
+  using ::mlir::AttributeInterface<SubElementAttrInterface, detail::SubElementAttrInterfaceInterfaceTraits>::AttributeInterface;
+  template <typename ConcreteAttr>
+  struct Trait : public detail::SubElementAttrInterfaceTrait<ConcreteAttr> {};
+  /// Walk all of the immediately nested sub-attributes and sub-types. This
+  /// method does not recurse into sub elements.
+  void walkImmediateSubElements(llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) const;
+  /// Replace the immediately nested sub-attributes and sub-types with those provided.
+  /// The order of the provided elements is derived from the order of the elements
+  /// returned by the callbacks of `walkImmediateSubElements`. The element at index 0
+  /// would replace the very first attribute given by `walkImmediateSubElements`.
+  /// On success, the new instance with the values replaced is returned. If replacement
+  /// fails, nullptr is returned.
+  /// 
+  /// Note that replacing the sub-elements of mutable types or attributes is
+  /// not currently supported by the interface. If an implementing type or
+  /// attribute is mutable, it should return `nullptr` if it has no mechanism
+  /// for replacing sub elements.
+  ::mlir::Attribute replaceImmediateSubElements(::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) const;
+
+    /// Walk all of the held sub-attributes and sub-types.
+    void walkSubElements(llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
+                         llvm::function_ref<void(mlir::Type)> walkTypesFn);
+
+    /// Recursively replace all of the nested sub-attributes and sub-types using the
+    /// provided map functions. Returns nullptr in the case of failure. See
+    /// `AttrTypeReplacer` for information on the support replacement function types.
+    template <typename... ReplacementFns>
+    ::mlir::Attribute replaceSubElements(ReplacementFns &&... replacementFns) {
+      AttrTypeReplacer replacer;
+      (replacer.addReplacement(std::forward<ReplacementFns>(replacementFns)), ...);
+      return replacer.replace(*this);
+    }
+  
+
+    /// Walk all of the held sub-attributes.
+    void walkSubAttrs(llvm::function_ref<void(mlir::Attribute)> walkFn) {
+      walkSubElements(walkFn, /*walkTypesFn=*/[](mlir::Type) {});
+    }
+    /// Walk all of the held sub-types.
+    void walkSubTypes(llvm::function_ref<void(mlir::Type)> walkFn) {
+      walkSubElements(/*walkAttrsFn=*/[](mlir::Attribute) {}, walkFn);
+    }
+  };
+namespace detail {
+  template <typename ConcreteAttr>
+  struct SubElementAttrInterfaceTrait : public ::mlir::AttributeInterface<SubElementAttrInterface, detail::SubElementAttrInterfaceInterfaceTraits>::Trait<ConcreteAttr> {
+    /// Walk all of the immediately nested sub-attributes and sub-types. This
+    /// method does not recurse into sub elements.
+    void walkImmediateSubElements(llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) const {
+      ::mlir::detail::walkImmediateSubElementsImpl(
+          (*static_cast<const ConcreteAttr *>(this)), walkAttrsFn, walkTypesFn);
+    }
+    /// Replace the immediately nested sub-attributes and sub-types with those provided.
+    /// The order of the provided elements is derived from the order of the elements
+    /// returned by the callbacks of `walkImmediateSubElements`. The element at index 0
+    /// would replace the very first attribute given by `walkImmediateSubElements`.
+    /// On success, the new instance with the values replaced is returned. If replacement
+    /// fails, nullptr is returned.
+    /// 
+    /// Note that replacing the sub-elements of mutable types or attributes is
+    /// not currently supported by the interface. If an implementing type or
+    /// attribute is mutable, it should return `nullptr` if it has no mechanism
+    /// for replacing sub elements.
+    ::mlir::Attribute replaceImmediateSubElements(::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) const {
+      return ::mlir::detail::replaceImmediateSubElementsImpl(
+           (*static_cast<const ConcreteAttr *>(this)), replAttrs, replTypes);
+    }
+
+    /// Walk all of the held sub-attributes and sub-types.
+    void walkSubElements(llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
+                         llvm::function_ref<void(mlir::Type)> walkTypesFn) {
+      SubElementAttrInterface interface((*static_cast<const ConcreteAttr *>(this)));
+      interface.walkSubElements(walkAttrsFn, walkTypesFn);
+    }
+
+    /// Recursively replace all of the nested sub-attributes and sub-types using the
+    /// provided map functions. Returns nullptr in the case of failure. See
+    /// `AttrTypeReplacer` for information on the support replacement function types.
+    template <typename... ReplacementFns>
+    ::mlir::Attribute replaceSubElements(ReplacementFns &&... replacementFns) {
+      AttrTypeReplacer replacer;
+      (replacer.addReplacement(std::forward<ReplacementFns>(replacementFns)), ...);
+      return replacer.replace((*static_cast<const ConcreteAttr *>(this)));
+    }
+  
+
+    /// Walk all of the held sub-attributes.
+    void walkSubAttrs(llvm::function_ref<void(mlir::Attribute)> walkFn) {
+      walkSubElements(walkFn, /*walkTypesFn=*/[](mlir::Type) {});
+    }
+    /// Walk all of the held sub-types.
+    void walkSubTypes(llvm::function_ref<void(mlir::Type)> walkFn) {
+      walkSubElements(/*walkAttrsFn=*/[](mlir::Attribute) {}, walkFn);
+    }
+  
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteAttr>
+void detail::SubElementAttrInterfaceInterfaceTraits::Model<ConcreteAttr>::walkImmediateSubElements(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).walkImmediateSubElements(walkAttrsFn, walkTypesFn);
+}
+template<typename ConcreteAttr>
+::mlir::Attribute detail::SubElementAttrInterfaceInterfaceTraits::Model<ConcreteAttr>::replaceImmediateSubElements(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).replaceImmediateSubElements(replAttrs, replTypes);
+}
+template<typename ConcreteAttr>
+void detail::SubElementAttrInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::walkImmediateSubElements(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) {
+  return static_cast<const ConcreteAttr *>(impl)->walkImmediateSubElements(tablegen_opaque_val, walkAttrsFn, walkTypesFn);
+}
+template<typename ConcreteAttr>
+::mlir::Attribute detail::SubElementAttrInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::replaceImmediateSubElements(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) {
+  return static_cast<const ConcreteAttr *>(impl)->replaceImmediateSubElements(tablegen_opaque_val, replAttrs, replTypes);
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+void detail::SubElementAttrInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::walkImmediateSubElements(::mlir::Attribute tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) const {
+::mlir::detail::walkImmediateSubElementsImpl(
+          (tablegen_opaque_val.cast<ConcreteAttr>()), walkAttrsFn, walkTypesFn);
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+::mlir::Attribute detail::SubElementAttrInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::replaceImmediateSubElements(::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) const {
+return ::mlir::detail::replaceImmediateSubElementsImpl(
+           (tablegen_opaque_val.cast<ConcreteAttr>()), replAttrs, replTypes);
+}
+} // namespace mlir

--- a/mlir/include/mlir/IR/SubElementTypeInterfaces.h.inc
+++ b/mlir/include/mlir/IR/SubElementTypeInterfaces.h.inc
@@ -1,0 +1,173 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class SubElementTypeInterface;
+namespace detail {
+struct SubElementTypeInterfaceInterfaceTraits {
+  struct Concept {
+    void (*walkImmediateSubElements)(const Concept *impl, ::mlir::Type , llvm::function_ref<void(mlir::Attribute)>, llvm::function_ref<void(mlir::Type)>);
+    ::mlir::Type (*replaceImmediateSubElements)(const Concept *impl, ::mlir::Type , ::llvm::ArrayRef<::mlir::Attribute>, ::llvm::ArrayRef<::mlir::Type>);
+  };
+  template<typename ConcreteType>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::SubElementTypeInterface;
+    Model() : Concept{walkImmediateSubElements, replaceImmediateSubElements} {}
+
+    static inline void walkImmediateSubElements(const Concept *impl, ::mlir::Type tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn);
+    static inline ::mlir::Type replaceImmediateSubElements(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes);
+  };
+  template<typename ConcreteType>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::SubElementTypeInterface;
+    FallbackModel() : Concept{walkImmediateSubElements, replaceImmediateSubElements} {}
+
+    static inline void walkImmediateSubElements(const Concept *impl, ::mlir::Type tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn);
+    static inline ::mlir::Type replaceImmediateSubElements(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes);
+  };
+  template<typename ConcreteModel, typename ConcreteType>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteType;
+    void walkImmediateSubElements(::mlir::Type tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) const;
+    ::mlir::Type replaceImmediateSubElements(::mlir::Type tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) const;
+  };
+};template <typename ConcreteType>
+struct SubElementTypeInterfaceTrait;
+
+} // namespace detail
+class SubElementTypeInterface : public ::mlir::TypeInterface<SubElementTypeInterface, detail::SubElementTypeInterfaceInterfaceTraits> {
+public:
+  using ::mlir::TypeInterface<SubElementTypeInterface, detail::SubElementTypeInterfaceInterfaceTraits>::TypeInterface;
+  template <typename ConcreteType>
+  struct Trait : public detail::SubElementTypeInterfaceTrait<ConcreteType> {};
+  /// Walk all of the immediately nested sub-attributes and sub-types. This
+  /// method does not recurse into sub elements.
+  void walkImmediateSubElements(llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) const;
+  /// Replace the immediately nested sub-attributes and sub-types with those provided.
+  /// The order of the provided elements is derived from the order of the elements
+  /// returned by the callbacks of `walkImmediateSubElements`. The element at index 0
+  /// would replace the very first attribute given by `walkImmediateSubElements`.
+  /// On success, the new instance with the values replaced is returned. If replacement
+  /// fails, nullptr is returned.
+  /// 
+  /// Note that replacing the sub-elements of mutable types or attributes is
+  /// not currently supported by the interface. If an implementing type or
+  /// attribute is mutable, it should return `nullptr` if it has no mechanism
+  /// for replacing sub elements.
+  ::mlir::Type replaceImmediateSubElements(::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) const;
+
+    /// Walk all of the held sub-attributes and sub-types.
+    void walkSubElements(llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
+                         llvm::function_ref<void(mlir::Type)> walkTypesFn);
+
+    /// Recursively replace all of the nested sub-attributes and sub-types using the
+    /// provided map functions. Returns nullptr in the case of failure. See
+    /// `AttrTypeReplacer` for information on the support replacement function types.
+    template <typename... ReplacementFns>
+    ::mlir::Type replaceSubElements(ReplacementFns &&... replacementFns) {
+      AttrTypeReplacer replacer;
+      (replacer.addReplacement(std::forward<ReplacementFns>(replacementFns)), ...);
+      return replacer.replace(*this);
+    }
+  
+
+    /// Walk all of the held sub-attributes.
+    void walkSubAttrs(llvm::function_ref<void(mlir::Attribute)> walkFn) {
+      walkSubElements(walkFn, /*walkTypesFn=*/[](mlir::Type) {});
+    }
+    /// Walk all of the held sub-types.
+    void walkSubTypes(llvm::function_ref<void(mlir::Type)> walkFn) {
+      walkSubElements(/*walkAttrsFn=*/[](mlir::Attribute) {}, walkFn);
+    }
+  };
+namespace detail {
+  template <typename ConcreteType>
+  struct SubElementTypeInterfaceTrait : public ::mlir::TypeInterface<SubElementTypeInterface, detail::SubElementTypeInterfaceInterfaceTraits>::Trait<ConcreteType> {
+    /// Walk all of the immediately nested sub-attributes and sub-types. This
+    /// method does not recurse into sub elements.
+    void walkImmediateSubElements(llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) const {
+      ::mlir::detail::walkImmediateSubElementsImpl(
+          (*static_cast<const ConcreteType *>(this)), walkAttrsFn, walkTypesFn);
+    }
+    /// Replace the immediately nested sub-attributes and sub-types with those provided.
+    /// The order of the provided elements is derived from the order of the elements
+    /// returned by the callbacks of `walkImmediateSubElements`. The element at index 0
+    /// would replace the very first attribute given by `walkImmediateSubElements`.
+    /// On success, the new instance with the values replaced is returned. If replacement
+    /// fails, nullptr is returned.
+    /// 
+    /// Note that replacing the sub-elements of mutable types or attributes is
+    /// not currently supported by the interface. If an implementing type or
+    /// attribute is mutable, it should return `nullptr` if it has no mechanism
+    /// for replacing sub elements.
+    ::mlir::Type replaceImmediateSubElements(::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) const {
+      return ::mlir::detail::replaceImmediateSubElementsImpl(
+           (*static_cast<const ConcreteType *>(this)), replAttrs, replTypes);
+    }
+
+    /// Walk all of the held sub-attributes and sub-types.
+    void walkSubElements(llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
+                         llvm::function_ref<void(mlir::Type)> walkTypesFn) {
+      SubElementTypeInterface interface((*static_cast<const ConcreteType *>(this)));
+      interface.walkSubElements(walkAttrsFn, walkTypesFn);
+    }
+
+    /// Recursively replace all of the nested sub-attributes and sub-types using the
+    /// provided map functions. Returns nullptr in the case of failure. See
+    /// `AttrTypeReplacer` for information on the support replacement function types.
+    template <typename... ReplacementFns>
+    ::mlir::Type replaceSubElements(ReplacementFns &&... replacementFns) {
+      AttrTypeReplacer replacer;
+      (replacer.addReplacement(std::forward<ReplacementFns>(replacementFns)), ...);
+      return replacer.replace((*static_cast<const ConcreteType *>(this)));
+    }
+  
+
+    /// Walk all of the held sub-attributes.
+    void walkSubAttrs(llvm::function_ref<void(mlir::Attribute)> walkFn) {
+      walkSubElements(walkFn, /*walkTypesFn=*/[](mlir::Type) {});
+    }
+    /// Walk all of the held sub-types.
+    void walkSubTypes(llvm::function_ref<void(mlir::Type)> walkFn) {
+      walkSubElements(/*walkAttrsFn=*/[](mlir::Attribute) {}, walkFn);
+    }
+  
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteType>
+void detail::SubElementTypeInterfaceInterfaceTraits::Model<ConcreteType>::walkImmediateSubElements(const Concept *impl, ::mlir::Type tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).walkImmediateSubElements(walkAttrsFn, walkTypesFn);
+}
+template<typename ConcreteType>
+::mlir::Type detail::SubElementTypeInterfaceInterfaceTraits::Model<ConcreteType>::replaceImmediateSubElements(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).replaceImmediateSubElements(replAttrs, replTypes);
+}
+template<typename ConcreteType>
+void detail::SubElementTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::walkImmediateSubElements(const Concept *impl, ::mlir::Type tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) {
+  return static_cast<const ConcreteType *>(impl)->walkImmediateSubElements(tablegen_opaque_val, walkAttrsFn, walkTypesFn);
+}
+template<typename ConcreteType>
+::mlir::Type detail::SubElementTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::replaceImmediateSubElements(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) {
+  return static_cast<const ConcreteType *>(impl)->replaceImmediateSubElements(tablegen_opaque_val, replAttrs, replTypes);
+}
+template<typename ConcreteModel, typename ConcreteType>
+void detail::SubElementTypeInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteType>::walkImmediateSubElements(::mlir::Type tablegen_opaque_val, llvm::function_ref<void(mlir::Attribute)> walkAttrsFn, llvm::function_ref<void(mlir::Type)> walkTypesFn) const {
+::mlir::detail::walkImmediateSubElementsImpl(
+          (tablegen_opaque_val.cast<ConcreteType>()), walkAttrsFn, walkTypesFn);
+}
+template<typename ConcreteModel, typename ConcreteType>
+::mlir::Type detail::SubElementTypeInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteType>::replaceImmediateSubElements(::mlir::Type tablegen_opaque_val, ::llvm::ArrayRef<::mlir::Attribute> replAttrs, ::llvm::ArrayRef<::mlir::Type> replTypes) const {
+return ::mlir::detail::replaceImmediateSubElementsImpl(
+           (tablegen_opaque_val.cast<ConcreteType>()), replAttrs, replTypes);
+}
+} // namespace mlir

--- a/mlir/include/mlir/IR/SymbolInterfaces.h.inc
+++ b/mlir/include/mlir/IR/SymbolInterfaces.h.inc
@@ -1,0 +1,540 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class SymbolOpInterface;
+namespace detail {
+struct SymbolOpInterfaceInterfaceTraits {
+  struct Concept {
+    StringAttr (*getNameAttr)(const Concept *impl, ::mlir::Operation *);
+    void (*setName)(const Concept *impl, ::mlir::Operation *, ::mlir::StringAttr);
+    mlir::SymbolTable::Visibility (*getVisibility)(const Concept *impl, ::mlir::Operation *);
+    bool (*isNested)(const Concept *impl, ::mlir::Operation *);
+    bool (*isPrivate)(const Concept *impl, ::mlir::Operation *);
+    bool (*isPublic)(const Concept *impl, ::mlir::Operation *);
+    void (*setVisibility)(const Concept *impl, ::mlir::Operation *, mlir::SymbolTable::Visibility);
+    void (*setNested)(const Concept *impl, ::mlir::Operation *);
+    void (*setPrivate)(const Concept *impl, ::mlir::Operation *);
+    void (*setPublic)(const Concept *impl, ::mlir::Operation *);
+    ::llvm::Optional<::mlir::SymbolTable::UseRange> (*getSymbolUses)(const Concept *impl, ::mlir::Operation *, ::mlir::Operation *);
+    bool (*symbolKnownUseEmpty)(const Concept *impl, ::mlir::Operation *, ::mlir::Operation *);
+    ::mlir::LogicalResult (*replaceAllSymbolUses)(const Concept *impl, ::mlir::Operation *, ::mlir::StringAttr, ::mlir::Operation *);
+    bool (*isOptionalSymbol)(const Concept *impl, ::mlir::Operation *);
+    bool (*canDiscardOnUseEmpty)(const Concept *impl, ::mlir::Operation *);
+    bool (*isDeclaration)(const Concept *impl, ::mlir::Operation *);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::SymbolOpInterface;
+    Model() : Concept{getNameAttr, setName, getVisibility, isNested, isPrivate, isPublic, setVisibility, setNested, setPrivate, setPublic, getSymbolUses, symbolKnownUseEmpty, replaceAllSymbolUses, isOptionalSymbol, canDiscardOnUseEmpty, isDeclaration} {}
+
+    static inline StringAttr getNameAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setName(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr name);
+    static inline mlir::SymbolTable::Visibility getVisibility(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool isNested(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool isPrivate(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool isPublic(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setVisibility(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, mlir::SymbolTable::Visibility vis);
+    static inline void setNested(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setPrivate(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setPublic(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::llvm::Optional<::mlir::SymbolTable::UseRange> getSymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Operation * from);
+    static inline bool symbolKnownUseEmpty(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Operation * from);
+    static inline ::mlir::LogicalResult replaceAllSymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr newSymbol, ::mlir::Operation * from);
+    static inline bool isOptionalSymbol(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool canDiscardOnUseEmpty(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool isDeclaration(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::SymbolOpInterface;
+    FallbackModel() : Concept{getNameAttr, setName, getVisibility, isNested, isPrivate, isPublic, setVisibility, setNested, setPrivate, setPublic, getSymbolUses, symbolKnownUseEmpty, replaceAllSymbolUses, isOptionalSymbol, canDiscardOnUseEmpty, isDeclaration} {}
+
+    static inline StringAttr getNameAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setName(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr name);
+    static inline mlir::SymbolTable::Visibility getVisibility(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool isNested(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool isPrivate(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool isPublic(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setVisibility(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, mlir::SymbolTable::Visibility vis);
+    static inline void setNested(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setPrivate(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline void setPublic(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::llvm::Optional<::mlir::SymbolTable::UseRange> getSymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Operation * from);
+    static inline bool symbolKnownUseEmpty(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Operation * from);
+    static inline ::mlir::LogicalResult replaceAllSymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr newSymbol, ::mlir::Operation * from);
+    static inline bool isOptionalSymbol(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool canDiscardOnUseEmpty(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline bool isDeclaration(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+    StringAttr getNameAttr(::mlir::Operation *tablegen_opaque_val) const;
+    void setName(::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr name) const;
+    mlir::SymbolTable::Visibility getVisibility(::mlir::Operation *tablegen_opaque_val) const;
+    bool isNested(::mlir::Operation *tablegen_opaque_val) const;
+    bool isPrivate(::mlir::Operation *tablegen_opaque_val) const;
+    bool isPublic(::mlir::Operation *tablegen_opaque_val) const;
+    void setVisibility(::mlir::Operation *tablegen_opaque_val, mlir::SymbolTable::Visibility vis) const;
+    void setNested(::mlir::Operation *tablegen_opaque_val) const;
+    void setPrivate(::mlir::Operation *tablegen_opaque_val) const;
+    void setPublic(::mlir::Operation *tablegen_opaque_val) const;
+    ::llvm::Optional<::mlir::SymbolTable::UseRange> getSymbolUses(::mlir::Operation *tablegen_opaque_val, ::mlir::Operation *from) const;
+    bool symbolKnownUseEmpty(::mlir::Operation *tablegen_opaque_val, ::mlir::Operation *from) const;
+    ::mlir::LogicalResult replaceAllSymbolUses(::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr newSymbol, ::mlir::Operation *from) const;
+    bool isOptionalSymbol(::mlir::Operation *tablegen_opaque_val) const;
+    bool canDiscardOnUseEmpty(::mlir::Operation *tablegen_opaque_val) const;
+    bool isDeclaration(::mlir::Operation *tablegen_opaque_val) const;
+  };
+};template <typename ConcreteOp>
+struct SymbolOpInterfaceTrait;
+
+} // namespace detail
+class SymbolOpInterface : public ::mlir::OpInterface<SymbolOpInterface, detail::SymbolOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<SymbolOpInterface, detail::SymbolOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::SymbolOpInterfaceTrait<ConcreteOp> {};
+  /// Returns the name of this symbol.
+  StringAttr getNameAttr();
+  /// Sets the name of this symbol.
+  void setName(::mlir::StringAttr name);
+  /// Gets the visibility of this symbol.
+  mlir::SymbolTable::Visibility getVisibility();
+  /// Returns true if this symbol has nested visibility.
+  bool isNested();
+  /// Returns true if this symbol has private visibility.
+  bool isPrivate();
+  /// Returns true if this symbol has public visibility.
+  bool isPublic();
+  /// Sets the visibility of this symbol.
+  void setVisibility(mlir::SymbolTable::Visibility vis);
+  /// Sets the visibility of this symbol to be nested.
+  void setNested();
+  /// Sets the visibility of this symbol to be private.
+  void setPrivate();
+  /// Sets the visibility of this symbol to be public.
+  void setPublic();
+  /// Get all of the uses of the current symbol that are nested within the
+  /// given operation 'from'.
+  /// Note: See mlir::SymbolTable::getSymbolUses for more details.
+  ::llvm::Optional<::mlir::SymbolTable::UseRange> getSymbolUses(::mlir::Operation * from);
+  /// Return if the current symbol is known to have no uses that are nested
+  /// within the given operation 'from'.
+  /// Note: See mlir::SymbolTable::symbolKnownUseEmpty for more details.
+  bool symbolKnownUseEmpty(::mlir::Operation * from);
+  /// Attempt to replace all uses of the current symbol with the provided
+  /// symbol 'newSymbol' that are nested within the given operation 'from'.
+  /// Note: See mlir::SymbolTable::replaceAllSymbolUses for more details.
+  ::mlir::LogicalResult replaceAllSymbolUses(::mlir::StringAttr newSymbol, ::mlir::Operation * from);
+  /// Returns true if this operation optionally defines a symbol based on the
+  /// presence of the symbol name.
+  bool isOptionalSymbol();
+  /// Returns true if this operation can be discarded if it has no remaining
+  /// symbol uses.
+  bool canDiscardOnUseEmpty();
+  /// Returns true if this operation is a declaration of a symbol (as opposed
+  /// to a definition).
+  bool isDeclaration();
+
+    /// Convenience version of `getNameAttr` that returns a StringRef.
+    StringRef getName() {
+      return getNameAttr().getValue();
+    }
+
+    /// Convenience version of `setName` that take a StringRef.
+    void setName(StringRef name) {
+      setName(StringAttr::get(this->getContext(), name));
+    }
+
+    /// Custom classof that handles the case where the symbol is optional.
+    static bool classof(Operation *op) {
+      auto *opConcept = getInterfaceFor(op);
+      if (!opConcept)
+        return false;
+      return !opConcept->isOptionalSymbol(opConcept, op) ||
+             op->getAttr(::mlir::SymbolTable::getSymbolAttrName());
+    }
+  
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct SymbolOpInterfaceTrait : public ::mlir::OpInterface<SymbolOpInterface, detail::SymbolOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+    /// Returns the name of this symbol.
+    StringAttr getNameAttr() {
+      return mlir::SymbolTable::getSymbolName(this->getOperation());
+    }
+    /// Sets the name of this symbol.
+    void setName(::mlir::StringAttr name) {
+      this->getOperation()->setAttr(
+            mlir::SymbolTable::getSymbolAttrName(), name);
+    }
+    /// Gets the visibility of this symbol.
+    mlir::SymbolTable::Visibility getVisibility() {
+      return mlir::SymbolTable::getSymbolVisibility(this->getOperation());
+    }
+    /// Returns true if this symbol has nested visibility.
+    bool isNested() {
+      return getVisibility() == mlir::SymbolTable::Visibility::Nested;
+    }
+    /// Returns true if this symbol has private visibility.
+    bool isPrivate() {
+      return getVisibility() == mlir::SymbolTable::Visibility::Private;
+    }
+    /// Returns true if this symbol has public visibility.
+    bool isPublic() {
+      return getVisibility() == mlir::SymbolTable::Visibility::Public;
+    }
+    /// Sets the visibility of this symbol.
+    void setVisibility(mlir::SymbolTable::Visibility vis) {
+      mlir::SymbolTable::setSymbolVisibility(this->getOperation(), vis);
+    }
+    /// Sets the visibility of this symbol to be nested.
+    void setNested() {
+      setVisibility(mlir::SymbolTable::Visibility::Nested);
+    }
+    /// Sets the visibility of this symbol to be private.
+    void setPrivate() {
+      setVisibility(mlir::SymbolTable::Visibility::Private);
+    }
+    /// Sets the visibility of this symbol to be public.
+    void setPublic() {
+      setVisibility(mlir::SymbolTable::Visibility::Public);
+    }
+    /// Get all of the uses of the current symbol that are nested within the
+    /// given operation 'from'.
+    /// Note: See mlir::SymbolTable::getSymbolUses for more details.
+    ::llvm::Optional<::mlir::SymbolTable::UseRange> getSymbolUses(::mlir::Operation * from) {
+      return ::mlir::SymbolTable::getSymbolUses(this->getOperation(), from);
+    }
+    /// Return if the current symbol is known to have no uses that are nested
+    /// within the given operation 'from'.
+    /// Note: See mlir::SymbolTable::symbolKnownUseEmpty for more details.
+    bool symbolKnownUseEmpty(::mlir::Operation * from) {
+      return ::mlir::SymbolTable::symbolKnownUseEmpty(this->getOperation(),
+                                                        from);
+    }
+    /// Attempt to replace all uses of the current symbol with the provided
+    /// symbol 'newSymbol' that are nested within the given operation 'from'.
+    /// Note: See mlir::SymbolTable::replaceAllSymbolUses for more details.
+    ::mlir::LogicalResult replaceAllSymbolUses(::mlir::StringAttr newSymbol, ::mlir::Operation * from) {
+      return ::mlir::SymbolTable::replaceAllSymbolUses(this->getOperation(),
+                                                         newSymbol, from);
+    }
+    /// Returns true if this operation optionally defines a symbol based on the
+    /// presence of the symbol name.
+    bool isOptionalSymbol() {
+      return false;
+    }
+    /// Returns true if this operation can be discarded if it has no remaining
+    /// symbol uses.
+    bool canDiscardOnUseEmpty() {
+      // By default, base this on the visibility alone. A symbol can be
+        // discarded as long as it is not public. Only public symbols may be
+        // visible from outside of the IR.
+        return getVisibility() != ::mlir::SymbolTable::Visibility::Public;
+    }
+    /// Returns true if this operation is a declaration of a symbol (as opposed
+    /// to a definition).
+    bool isDeclaration() {
+      // By default, assume that the operation defines a symbol.
+        return false;
+    }
+    static ::mlir::LogicalResult verifyTrait(::mlir::Operation *op) {
+      // If this is an optional symbol, bail out early if possible.
+    auto concreteOp = cast<ConcreteOp>(op);
+    if (concreteOp.isOptionalSymbol()) {
+      if(!concreteOp->getAttr(::mlir::SymbolTable::getSymbolAttrName()))
+        return success();
+    }
+    if (::mlir::failed(::mlir::detail::verifySymbol(op)))
+      return ::mlir::failure();
+    if (concreteOp.isDeclaration() && concreteOp.isPublic())
+      return concreteOp.emitOpError("symbol declaration cannot have public "
+             "visibility");
+    return success();
+    }
+
+    using Visibility = mlir::SymbolTable::Visibility;
+
+    /// Convenience version of `getNameAttr` that returns a StringRef.
+    StringRef getName() {
+      return getNameAttr().getValue();
+    }
+
+    /// Convenience version of `setName` that take a StringRef.
+    void setName(StringRef name) {
+      setName(StringAttr::get((*static_cast<ConcreteOp *>(this))->getContext(), name));
+    }
+  
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class SymbolUserOpInterface;
+namespace detail {
+struct SymbolUserOpInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::LogicalResult (*verifySymbolUses)(const Concept *impl, ::mlir::Operation *, ::mlir::SymbolTableCollection &);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::SymbolUserOpInterface;
+    Model() : Concept{verifySymbolUses} {}
+
+    static inline ::mlir::LogicalResult verifySymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::SymbolTableCollection & symbolTable);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::SymbolUserOpInterface;
+    FallbackModel() : Concept{verifySymbolUses} {}
+
+    static inline ::mlir::LogicalResult verifySymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::SymbolTableCollection & symbolTable);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+  };
+};template <typename ConcreteOp>
+struct SymbolUserOpInterfaceTrait;
+
+} // namespace detail
+class SymbolUserOpInterface : public ::mlir::OpInterface<SymbolUserOpInterface, detail::SymbolUserOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<SymbolUserOpInterface, detail::SymbolUserOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::SymbolUserOpInterfaceTrait<ConcreteOp> {};
+  /// Verify the symbol uses held by this operation.
+  ::mlir::LogicalResult verifySymbolUses(::mlir::SymbolTableCollection & symbolTable);
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct SymbolUserOpInterfaceTrait : public ::mlir::OpInterface<SymbolUserOpInterface, detail::SymbolUserOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+StringAttr detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::getNameAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  // Don't rely on the trait implementation as optional symbol operations
+        // may override this.
+        return mlir::SymbolTable::getSymbolName((llvm::cast<ConcreteOp>(tablegen_opaque_val)));
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::setName(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr name) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).setName(name);
+}
+template<typename ConcreteOp>
+mlir::SymbolTable::Visibility detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::getVisibility(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getVisibility();
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::isNested(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).isNested();
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::isPrivate(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).isPrivate();
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::isPublic(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).isPublic();
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::setVisibility(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, mlir::SymbolTable::Visibility vis) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).setVisibility(vis);
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::setNested(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).setNested();
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::setPrivate(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).setPrivate();
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::setPublic(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).setPublic();
+}
+template<typename ConcreteOp>
+::llvm::Optional<::mlir::SymbolTable::UseRange> detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::getSymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Operation * from) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getSymbolUses(from);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::symbolKnownUseEmpty(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Operation * from) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).symbolKnownUseEmpty(from);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::replaceAllSymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr newSymbol, ::mlir::Operation * from) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).replaceAllSymbolUses(newSymbol, from);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::isOptionalSymbol(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).isOptionalSymbol();
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::canDiscardOnUseEmpty(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).canDiscardOnUseEmpty();
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::Model<ConcreteOp>::isDeclaration(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).isDeclaration();
+}
+template<typename ConcreteOp>
+StringAttr detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getNameAttr(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getNameAttr(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::setName(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr name) {
+  return static_cast<const ConcreteOp *>(impl)->setName(tablegen_opaque_val, name);
+}
+template<typename ConcreteOp>
+mlir::SymbolTable::Visibility detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getVisibility(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getVisibility(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::isNested(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->isNested(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::isPrivate(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->isPrivate(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::isPublic(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->isPublic(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::setVisibility(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, mlir::SymbolTable::Visibility vis) {
+  return static_cast<const ConcreteOp *>(impl)->setVisibility(tablegen_opaque_val, vis);
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::setNested(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->setNested(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::setPrivate(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->setPrivate(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::setPublic(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->setPublic(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::llvm::Optional<::mlir::SymbolTable::UseRange> detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getSymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Operation * from) {
+  return static_cast<const ConcreteOp *>(impl)->getSymbolUses(tablegen_opaque_val, from);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::symbolKnownUseEmpty(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::Operation * from) {
+  return static_cast<const ConcreteOp *>(impl)->symbolKnownUseEmpty(tablegen_opaque_val, from);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::replaceAllSymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr newSymbol, ::mlir::Operation * from) {
+  return static_cast<const ConcreteOp *>(impl)->replaceAllSymbolUses(tablegen_opaque_val, newSymbol, from);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::isOptionalSymbol(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->isOptionalSymbol(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::canDiscardOnUseEmpty(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->canDiscardOnUseEmpty(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::isDeclaration(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->isDeclaration(tablegen_opaque_val);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+StringAttr detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getNameAttr(::mlir::Operation *tablegen_opaque_val) const {
+return mlir::SymbolTable::getSymbolName(this->getOperation());
+}
+template<typename ConcreteModel, typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::setName(::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr name) const {
+this->getOperation()->setAttr(
+            mlir::SymbolTable::getSymbolAttrName(), name);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+mlir::SymbolTable::Visibility detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getVisibility(::mlir::Operation *tablegen_opaque_val) const {
+return mlir::SymbolTable::getSymbolVisibility(this->getOperation());
+}
+template<typename ConcreteModel, typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::isNested(::mlir::Operation *tablegen_opaque_val) const {
+return getVisibility() == mlir::SymbolTable::Visibility::Nested;
+}
+template<typename ConcreteModel, typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::isPrivate(::mlir::Operation *tablegen_opaque_val) const {
+return getVisibility() == mlir::SymbolTable::Visibility::Private;
+}
+template<typename ConcreteModel, typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::isPublic(::mlir::Operation *tablegen_opaque_val) const {
+return getVisibility() == mlir::SymbolTable::Visibility::Public;
+}
+template<typename ConcreteModel, typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::setVisibility(::mlir::Operation *tablegen_opaque_val, mlir::SymbolTable::Visibility vis) const {
+mlir::SymbolTable::setSymbolVisibility(this->getOperation(), vis);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::setNested(::mlir::Operation *tablegen_opaque_val) const {
+setVisibility(mlir::SymbolTable::Visibility::Nested);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::setPrivate(::mlir::Operation *tablegen_opaque_val) const {
+setVisibility(mlir::SymbolTable::Visibility::Private);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+void detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::setPublic(::mlir::Operation *tablegen_opaque_val) const {
+setVisibility(mlir::SymbolTable::Visibility::Public);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::llvm::Optional<::mlir::SymbolTable::UseRange> detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getSymbolUses(::mlir::Operation *tablegen_opaque_val, ::mlir::Operation *from) const {
+return ::mlir::SymbolTable::getSymbolUses(this->getOperation(), from);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::symbolKnownUseEmpty(::mlir::Operation *tablegen_opaque_val, ::mlir::Operation *from) const {
+return ::mlir::SymbolTable::symbolKnownUseEmpty(this->getOperation(),
+                                                        from);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::mlir::LogicalResult detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::replaceAllSymbolUses(::mlir::Operation *tablegen_opaque_val, ::mlir::StringAttr newSymbol, ::mlir::Operation *from) const {
+return ::mlir::SymbolTable::replaceAllSymbolUses(this->getOperation(),
+                                                         newSymbol, from);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::isOptionalSymbol(::mlir::Operation *tablegen_opaque_val) const {
+return false;
+}
+template<typename ConcreteModel, typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::canDiscardOnUseEmpty(::mlir::Operation *tablegen_opaque_val) const {
+// By default, base this on the visibility alone. A symbol can be
+        // discarded as long as it is not public. Only public symbols may be
+        // visible from outside of the IR.
+        return getVisibility() != ::mlir::SymbolTable::Visibility::Public;
+}
+template<typename ConcreteModel, typename ConcreteOp>
+bool detail::SymbolOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::isDeclaration(::mlir::Operation *tablegen_opaque_val) const {
+// By default, assume that the operation defines a symbol.
+        return false;
+}
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::SymbolUserOpInterfaceInterfaceTraits::Model<ConcreteOp>::verifySymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::SymbolTableCollection & symbolTable) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).verifySymbolUses(symbolTable);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::SymbolUserOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::verifySymbolUses(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::SymbolTableCollection & symbolTable) {
+  return static_cast<const ConcreteOp *>(impl)->verifySymbolUses(tablegen_opaque_val, symbolTable);
+}
+} // namespace mlir

--- a/mlir/include/mlir/IR/TensorEncInterfaces.h.inc
+++ b/mlir/include/mlir/IR/TensorEncInterfaces.h.inc
@@ -1,0 +1,66 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class VerifiableTensorEncoding;
+namespace detail {
+struct VerifiableTensorEncodingInterfaceTraits {
+  struct Concept {
+    ::mlir::LogicalResult (*verifyEncoding)(const Concept *impl, ::mlir::Attribute , ArrayRef<int64_t>, Type, ::llvm::function_ref<::mlir::InFlightDiagnostic()>);
+  };
+  template<typename ConcreteAttr>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::VerifiableTensorEncoding;
+    Model() : Concept{verifyEncoding} {}
+
+    static inline ::mlir::LogicalResult verifyEncoding(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ArrayRef<int64_t> shape, Type elementType, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError);
+  };
+  template<typename ConcreteAttr>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::VerifiableTensorEncoding;
+    FallbackModel() : Concept{verifyEncoding} {}
+
+    static inline ::mlir::LogicalResult verifyEncoding(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ArrayRef<int64_t> shape, Type elementType, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError);
+  };
+  template<typename ConcreteModel, typename ConcreteAttr>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteAttr;
+  };
+};template <typename ConcreteAttr>
+struct VerifiableTensorEncodingTrait;
+
+} // namespace detail
+class VerifiableTensorEncoding : public ::mlir::AttributeInterface<VerifiableTensorEncoding, detail::VerifiableTensorEncodingInterfaceTraits> {
+public:
+  using ::mlir::AttributeInterface<VerifiableTensorEncoding, detail::VerifiableTensorEncodingInterfaceTraits>::AttributeInterface;
+  template <typename ConcreteAttr>
+  struct Trait : public detail::VerifiableTensorEncodingTrait<ConcreteAttr> {};
+  /// Verifies the encoding is valid for a tensor type with the
+  /// given shape and element type. Generates a diagnostic using
+  /// the supplied callback on failure.
+  ::mlir::LogicalResult verifyEncoding(ArrayRef<int64_t> shape, Type elementType, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) const;
+};
+namespace detail {
+  template <typename ConcreteAttr>
+  struct VerifiableTensorEncodingTrait : public ::mlir::AttributeInterface<VerifiableTensorEncoding, detail::VerifiableTensorEncodingInterfaceTraits>::Trait<ConcreteAttr> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteAttr>
+::mlir::LogicalResult detail::VerifiableTensorEncodingInterfaceTraits::Model<ConcreteAttr>::verifyEncoding(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ArrayRef<int64_t> shape, Type elementType, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).verifyEncoding(shape, elementType, emitError);
+}
+template<typename ConcreteAttr>
+::mlir::LogicalResult detail::VerifiableTensorEncodingInterfaceTraits::FallbackModel<ConcreteAttr>::verifyEncoding(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ArrayRef<int64_t> shape, Type elementType, ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError) {
+  return static_cast<const ConcreteAttr *>(impl)->verifyEncoding(tablegen_opaque_val, shape, elementType, emitError);
+}
+} // namespace mlir

--- a/mlir/include/mlir/Interfaces/CallInterfaces.h.inc
+++ b/mlir/include/mlir/Interfaces/CallInterfaces.h.inc
@@ -1,0 +1,161 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class CallOpInterface;
+namespace detail {
+struct CallOpInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::CallInterfaceCallable (*getCallableForCallee)(const Concept *impl, ::mlir::Operation *);
+    ::mlir::Operation::operand_range (*getArgOperands)(const Concept *impl, ::mlir::Operation *);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::CallOpInterface;
+    Model() : Concept{getCallableForCallee, getArgOperands} {}
+
+    static inline ::mlir::CallInterfaceCallable getCallableForCallee(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::Operation::operand_range getArgOperands(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::CallOpInterface;
+    FallbackModel() : Concept{getCallableForCallee, getArgOperands} {}
+
+    static inline ::mlir::CallInterfaceCallable getCallableForCallee(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::mlir::Operation::operand_range getArgOperands(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+  };
+};template <typename ConcreteOp>
+struct CallOpInterfaceTrait;
+
+} // namespace detail
+class CallOpInterface : public ::mlir::OpInterface<CallOpInterface, detail::CallOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<CallOpInterface, detail::CallOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::CallOpInterfaceTrait<ConcreteOp> {};
+  /// Returns the callee of this call-like operation. A `callee` is either a
+  /// reference to a symbol, via SymbolRefAttr, or a reference to a defined
+  /// SSA value. If the reference is an SSA value, the SSA value corresponds
+  /// to a region of a lambda-like operation.
+  ::mlir::CallInterfaceCallable getCallableForCallee();
+  /// Returns the operands within this call that are used as arguments to the
+  /// callee.
+  ::mlir::Operation::operand_range getArgOperands();
+
+    /// Resolve the callable operation for given callee to a
+    /// CallableOpInterface, or nullptr if a valid callable was not resolved.
+    /// `symbolTable` is an optional parameter that will allow for using a
+    /// cached symbol table for symbol lookups instead of performing an O(N)
+    /// scan.
+    Operation *resolveCallable(SymbolTableCollection *symbolTable = nullptr);
+  
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct CallOpInterfaceTrait : public ::mlir::OpInterface<CallOpInterface, detail::CallOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class CallableOpInterface;
+namespace detail {
+struct CallableOpInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::Region *(*getCallableRegion)(const Concept *impl, ::mlir::Operation *);
+    ::llvm::ArrayRef<::mlir::Type> (*getCallableResults)(const Concept *impl, ::mlir::Operation *);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::CallableOpInterface;
+    Model() : Concept{getCallableRegion, getCallableResults} {}
+
+    static inline ::mlir::Region *getCallableRegion(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::llvm::ArrayRef<::mlir::Type> getCallableResults(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::CallableOpInterface;
+    FallbackModel() : Concept{getCallableRegion, getCallableResults} {}
+
+    static inline ::mlir::Region *getCallableRegion(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline ::llvm::ArrayRef<::mlir::Type> getCallableResults(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+  };
+};template <typename ConcreteOp>
+struct CallableOpInterfaceTrait;
+
+} // namespace detail
+class CallableOpInterface : public ::mlir::OpInterface<CallableOpInterface, detail::CallableOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<CallableOpInterface, detail::CallableOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::CallableOpInterfaceTrait<ConcreteOp> {};
+  /// Returns the region on the current operation that is callable. This may
+  /// return null in the case of an external callable object, e.g. an external
+  /// function.
+  ::mlir::Region *getCallableRegion();
+  /// Returns the results types that the callable region produces when
+  /// executed.
+  ::llvm::ArrayRef<::mlir::Type> getCallableResults();
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct CallableOpInterfaceTrait : public ::mlir::OpInterface<CallableOpInterface, detail::CallableOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::CallInterfaceCallable detail::CallOpInterfaceInterfaceTraits::Model<ConcreteOp>::getCallableForCallee(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getCallableForCallee();
+}
+template<typename ConcreteOp>
+::mlir::Operation::operand_range detail::CallOpInterfaceInterfaceTraits::Model<ConcreteOp>::getArgOperands(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getArgOperands();
+}
+template<typename ConcreteOp>
+::mlir::CallInterfaceCallable detail::CallOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getCallableForCallee(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getCallableForCallee(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::mlir::Operation::operand_range detail::CallOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getArgOperands(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getArgOperands(tablegen_opaque_val);
+}
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::Region *detail::CallableOpInterfaceInterfaceTraits::Model<ConcreteOp>::getCallableRegion(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getCallableRegion();
+}
+template<typename ConcreteOp>
+::llvm::ArrayRef<::mlir::Type> detail::CallableOpInterfaceInterfaceTraits::Model<ConcreteOp>::getCallableResults(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getCallableResults();
+}
+template<typename ConcreteOp>
+::mlir::Region *detail::CallableOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getCallableRegion(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getCallableRegion(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+::llvm::ArrayRef<::mlir::Type> detail::CallableOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getCallableResults(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getCallableResults(tablegen_opaque_val);
+}
+} // namespace mlir

--- a/mlir/include/mlir/Interfaces/CastInterfaces.h.inc
+++ b/mlir/include/mlir/Interfaces/CastInterfaces.h.inc
@@ -1,0 +1,75 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class CastOpInterface;
+namespace detail {
+struct CastOpInterfaceInterfaceTraits {
+  struct Concept {
+    bool (*areCastCompatible)(::mlir::TypeRange, ::mlir::TypeRange);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::CastOpInterface;
+    Model() : Concept{areCastCompatible} {}
+
+    static inline bool areCastCompatible(::mlir::TypeRange inputs, ::mlir::TypeRange outputs);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::CastOpInterface;
+    FallbackModel() : Concept{areCastCompatible} {}
+
+    static inline bool areCastCompatible(::mlir::TypeRange inputs, ::mlir::TypeRange outputs);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+  };
+};template <typename ConcreteOp>
+struct CastOpInterfaceTrait;
+
+} // namespace detail
+class CastOpInterface : public ::mlir::OpInterface<CastOpInterface, detail::CastOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<CastOpInterface, detail::CastOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::CastOpInterfaceTrait<ConcreteOp> {};
+  /// Returns true if the given set of input and result types are compatible
+  /// to cast using this cast operation.
+  bool areCastCompatible(::mlir::TypeRange inputs, ::mlir::TypeRange outputs);
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct CastOpInterfaceTrait : public ::mlir::OpInterface<CastOpInterface, detail::CastOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+    static ::mlir::LogicalResult verifyTrait(::mlir::Operation *op) {
+      return impl::verifyCastInterfaceOp(op, ConcreteOp::areCastCompatible);
+    }
+
+    /// Attempt to fold the given cast operation.
+    static LogicalResult foldTrait(Operation *op, ArrayRef<Attribute> operands,
+                                   SmallVectorImpl<OpFoldResult> &results) {
+      return impl::foldCastInterfaceOp(op, operands, results);
+    }
+  
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+bool detail::CastOpInterfaceInterfaceTraits::Model<ConcreteOp>::areCastCompatible(::mlir::TypeRange inputs, ::mlir::TypeRange outputs) {
+  return ConcreteOp::areCastCompatible(inputs, outputs);
+}
+template<typename ConcreteOp>
+bool detail::CastOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::areCastCompatible(::mlir::TypeRange inputs, ::mlir::TypeRange outputs) {
+  return ConcreteOp::areCastCompatible(inputs, outputs);
+}
+} // namespace mlir

--- a/mlir/include/mlir/Interfaces/DataLayoutAttrInterface.h.inc
+++ b/mlir/include/mlir/Interfaces/DataLayoutAttrInterface.h.inc
@@ -1,0 +1,258 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class DataLayoutEntryInterface;
+namespace detail {
+struct DataLayoutEntryInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::DataLayoutEntryKey (*getKey)(const Concept *impl, ::mlir::Attribute );
+    ::mlir::Attribute (*getValue)(const Concept *impl, ::mlir::Attribute );
+    ::mlir::LogicalResult (*verifyEntry)(const Concept *impl, ::mlir::Attribute , ::mlir::Location);
+  };
+  template<typename ConcreteAttr>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::DataLayoutEntryInterface;
+    Model() : Concept{getKey, getValue, verifyEntry} {}
+
+    static inline ::mlir::DataLayoutEntryKey getKey(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::Attribute getValue(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::LogicalResult verifyEntry(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc);
+  };
+  template<typename ConcreteAttr>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::DataLayoutEntryInterface;
+    FallbackModel() : Concept{getKey, getValue, verifyEntry} {}
+
+    static inline ::mlir::DataLayoutEntryKey getKey(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::Attribute getValue(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::LogicalResult verifyEntry(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc);
+  };
+  template<typename ConcreteModel, typename ConcreteAttr>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteAttr;
+    ::mlir::LogicalResult verifyEntry(::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc) const;
+  };
+};template <typename ConcreteAttr>
+struct DataLayoutEntryInterfaceTrait;
+
+} // namespace detail
+class DataLayoutEntryInterface : public ::mlir::AttributeInterface<DataLayoutEntryInterface, detail::DataLayoutEntryInterfaceInterfaceTraits> {
+public:
+  using ::mlir::AttributeInterface<DataLayoutEntryInterface, detail::DataLayoutEntryInterfaceInterfaceTraits>::AttributeInterface;
+  template <typename ConcreteAttr>
+  struct Trait : public detail::DataLayoutEntryInterfaceTrait<ConcreteAttr> {};
+  /// Returns the key of the this layout entry.
+  ::mlir::DataLayoutEntryKey getKey() const;
+  /// Returns the value of this layout entry.
+  ::mlir::Attribute getValue() const;
+  /// Checks that the entry is well-formed, reports errors at the provided location.
+  ::mlir::LogicalResult verifyEntry(::mlir::Location loc) const;
+
+    /// Returns `true` if the key of this entry is a type.
+    bool isTypeEntry() {
+      return getKey().is<::mlir::Type>();
+    }
+  
+};
+namespace detail {
+  template <typename ConcreteAttr>
+  struct DataLayoutEntryInterfaceTrait : public ::mlir::AttributeInterface<DataLayoutEntryInterface, detail::DataLayoutEntryInterfaceInterfaceTraits>::Trait<ConcreteAttr> {
+    /// Checks that the entry is well-formed, reports errors at the provided location.
+    ::mlir::LogicalResult verifyEntry(::mlir::Location loc) const {
+      return ::mlir::success();
+    }
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class DataLayoutSpecInterface;
+namespace detail {
+struct DataLayoutSpecInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::DataLayoutSpecInterface (*combineWith)(const Concept *impl, ::mlir::Attribute , ::llvm::ArrayRef<::mlir::DataLayoutSpecInterface>);
+    ::mlir::DataLayoutEntryListRef (*getEntries)(const Concept *impl, ::mlir::Attribute );
+    ::mlir::DataLayoutEntryList (*getSpecForType)(const Concept *impl, ::mlir::Attribute , ::mlir::TypeID);
+    ::mlir::DataLayoutEntryInterface (*getSpecForIdentifier)(const Concept *impl, ::mlir::Attribute , ::mlir::StringAttr);
+    ::mlir::LogicalResult (*verifySpec)(const Concept *impl, ::mlir::Attribute , ::mlir::Location);
+  };
+  template<typename ConcreteAttr>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::DataLayoutSpecInterface;
+    Model() : Concept{combineWith, getEntries, getSpecForType, getSpecForIdentifier, verifySpec} {}
+
+    static inline ::mlir::DataLayoutSpecInterface combineWith(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::DataLayoutSpecInterface> specs);
+    static inline ::mlir::DataLayoutEntryListRef getEntries(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::DataLayoutEntryList getSpecForType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID type);
+    static inline ::mlir::DataLayoutEntryInterface getSpecForIdentifier(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::StringAttr identifier);
+    static inline ::mlir::LogicalResult verifySpec(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc);
+  };
+  template<typename ConcreteAttr>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::DataLayoutSpecInterface;
+    FallbackModel() : Concept{combineWith, getEntries, getSpecForType, getSpecForIdentifier, verifySpec} {}
+
+    static inline ::mlir::DataLayoutSpecInterface combineWith(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::DataLayoutSpecInterface> specs);
+    static inline ::mlir::DataLayoutEntryListRef getEntries(const Concept *impl, ::mlir::Attribute tablegen_opaque_val);
+    static inline ::mlir::DataLayoutEntryList getSpecForType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID type);
+    static inline ::mlir::DataLayoutEntryInterface getSpecForIdentifier(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::StringAttr identifier);
+    static inline ::mlir::LogicalResult verifySpec(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc);
+  };
+  template<typename ConcreteModel, typename ConcreteAttr>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteAttr;
+    ::mlir::DataLayoutEntryList getSpecForType(::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID type) const;
+    ::mlir::DataLayoutEntryInterface getSpecForIdentifier(::mlir::Attribute tablegen_opaque_val, ::mlir::StringAttr identifier) const;
+    ::mlir::LogicalResult verifySpec(::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc) const;
+  };
+};template <typename ConcreteAttr>
+struct DataLayoutSpecInterfaceTrait;
+
+} // namespace detail
+class DataLayoutSpecInterface : public ::mlir::AttributeInterface<DataLayoutSpecInterface, detail::DataLayoutSpecInterfaceInterfaceTraits> {
+public:
+  using ::mlir::AttributeInterface<DataLayoutSpecInterface, detail::DataLayoutSpecInterfaceInterfaceTraits>::AttributeInterface;
+  template <typename ConcreteAttr>
+  struct Trait : public detail::DataLayoutSpecInterfaceTrait<ConcreteAttr> {};
+  /// Combines the current layout with the given list of layouts, provided from the outermost (oldest) to the innermost (newest). Returns null on failure.
+  ::mlir::DataLayoutSpecInterface combineWith(::llvm::ArrayRef<::mlir::DataLayoutSpecInterface> specs) const;
+  /// Returns the list of layout entries.
+  ::mlir::DataLayoutEntryListRef getEntries() const;
+  /// Returns a copy of the entries related to a specific type class regardles of type parameters.
+  ::mlir::DataLayoutEntryList getSpecForType(::mlir::TypeID type) const;
+  /// Returns the entry related to the given identifier, if present.
+  ::mlir::DataLayoutEntryInterface getSpecForIdentifier(::mlir::StringAttr identifier) const;
+  /// Verifies the validity of the specification and reports any errors at the given location.
+  ::mlir::LogicalResult verifySpec(::mlir::Location loc) const;
+
+    /// Returns a copy of the entries related to the type specified as template
+    /// parameter.
+    template <typename Ty>
+    DataLayoutEntryList getSpecForType() {
+      return getSpecForType(TypeID::get<Ty>());
+    }
+
+    /// Populates the given maps with lists of entries grouped by the type or
+    /// identifier they are associated with. Users are not expected to call this
+    /// method directly.
+    void bucketEntriesByType(
+        ::llvm::DenseMap<::mlir::TypeID, ::mlir::DataLayoutEntryList> &types,
+        ::llvm::DenseMap<::mlir::StringAttr,
+                         ::mlir::DataLayoutEntryInterface> &ids);
+  
+};
+namespace detail {
+  template <typename ConcreteAttr>
+  struct DataLayoutSpecInterfaceTrait : public ::mlir::AttributeInterface<DataLayoutSpecInterface, detail::DataLayoutSpecInterfaceInterfaceTraits>::Trait<ConcreteAttr> {
+    /// Returns a copy of the entries related to a specific type class regardles of type parameters.
+    ::mlir::DataLayoutEntryList getSpecForType(::mlir::TypeID type) const {
+      return ::mlir::detail::filterEntriesForType((*static_cast<const ConcreteAttr *>(this)).getEntries(), type);
+    }
+    /// Returns the entry related to the given identifier, if present.
+    ::mlir::DataLayoutEntryInterface getSpecForIdentifier(::mlir::StringAttr identifier) const {
+      return ::mlir::detail::filterEntryForIdentifier((*static_cast<const ConcreteAttr *>(this)).getEntries(),
+                                                        identifier);
+    }
+    /// Verifies the validity of the specification and reports any errors at the given location.
+    ::mlir::LogicalResult verifySpec(::mlir::Location loc) const {
+      return ::mlir::detail::verifyDataLayoutSpec((*static_cast<const ConcreteAttr *>(this)), loc);
+    }
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteAttr>
+::mlir::DataLayoutEntryKey detail::DataLayoutEntryInterfaceInterfaceTraits::Model<ConcreteAttr>::getKey(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getKey();
+}
+template<typename ConcreteAttr>
+::mlir::Attribute detail::DataLayoutEntryInterfaceInterfaceTraits::Model<ConcreteAttr>::getValue(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getValue();
+}
+template<typename ConcreteAttr>
+::mlir::LogicalResult detail::DataLayoutEntryInterfaceInterfaceTraits::Model<ConcreteAttr>::verifyEntry(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).verifyEntry(loc);
+}
+template<typename ConcreteAttr>
+::mlir::DataLayoutEntryKey detail::DataLayoutEntryInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::getKey(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return static_cast<const ConcreteAttr *>(impl)->getKey(tablegen_opaque_val);
+}
+template<typename ConcreteAttr>
+::mlir::Attribute detail::DataLayoutEntryInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::getValue(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return static_cast<const ConcreteAttr *>(impl)->getValue(tablegen_opaque_val);
+}
+template<typename ConcreteAttr>
+::mlir::LogicalResult detail::DataLayoutEntryInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::verifyEntry(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc) {
+  return static_cast<const ConcreteAttr *>(impl)->verifyEntry(tablegen_opaque_val, loc);
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+::mlir::LogicalResult detail::DataLayoutEntryInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::verifyEntry(::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc) const {
+return ::mlir::success();
+}
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteAttr>
+::mlir::DataLayoutSpecInterface detail::DataLayoutSpecInterfaceInterfaceTraits::Model<ConcreteAttr>::combineWith(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::DataLayoutSpecInterface> specs) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).combineWith(specs);
+}
+template<typename ConcreteAttr>
+::mlir::DataLayoutEntryListRef detail::DataLayoutSpecInterfaceInterfaceTraits::Model<ConcreteAttr>::getEntries(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getEntries();
+}
+template<typename ConcreteAttr>
+::mlir::DataLayoutEntryList detail::DataLayoutSpecInterfaceInterfaceTraits::Model<ConcreteAttr>::getSpecForType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID type) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getSpecForType(type);
+}
+template<typename ConcreteAttr>
+::mlir::DataLayoutEntryInterface detail::DataLayoutSpecInterfaceInterfaceTraits::Model<ConcreteAttr>::getSpecForIdentifier(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::StringAttr identifier) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).getSpecForIdentifier(identifier);
+}
+template<typename ConcreteAttr>
+::mlir::LogicalResult detail::DataLayoutSpecInterfaceInterfaceTraits::Model<ConcreteAttr>::verifySpec(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc) {
+  return (tablegen_opaque_val.cast<ConcreteAttr>()).verifySpec(loc);
+}
+template<typename ConcreteAttr>
+::mlir::DataLayoutSpecInterface detail::DataLayoutSpecInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::combineWith(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::llvm::ArrayRef<::mlir::DataLayoutSpecInterface> specs) {
+  return static_cast<const ConcreteAttr *>(impl)->combineWith(tablegen_opaque_val, specs);
+}
+template<typename ConcreteAttr>
+::mlir::DataLayoutEntryListRef detail::DataLayoutSpecInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::getEntries(const Concept *impl, ::mlir::Attribute tablegen_opaque_val) {
+  return static_cast<const ConcreteAttr *>(impl)->getEntries(tablegen_opaque_val);
+}
+template<typename ConcreteAttr>
+::mlir::DataLayoutEntryList detail::DataLayoutSpecInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::getSpecForType(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID type) {
+  return static_cast<const ConcreteAttr *>(impl)->getSpecForType(tablegen_opaque_val, type);
+}
+template<typename ConcreteAttr>
+::mlir::DataLayoutEntryInterface detail::DataLayoutSpecInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::getSpecForIdentifier(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::StringAttr identifier) {
+  return static_cast<const ConcreteAttr *>(impl)->getSpecForIdentifier(tablegen_opaque_val, identifier);
+}
+template<typename ConcreteAttr>
+::mlir::LogicalResult detail::DataLayoutSpecInterfaceInterfaceTraits::FallbackModel<ConcreteAttr>::verifySpec(const Concept *impl, ::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc) {
+  return static_cast<const ConcreteAttr *>(impl)->verifySpec(tablegen_opaque_val, loc);
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+::mlir::DataLayoutEntryList detail::DataLayoutSpecInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::getSpecForType(::mlir::Attribute tablegen_opaque_val, ::mlir::TypeID type) const {
+return ::mlir::detail::filterEntriesForType((tablegen_opaque_val.cast<ConcreteAttr>()).getEntries(), type);
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+::mlir::DataLayoutEntryInterface detail::DataLayoutSpecInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::getSpecForIdentifier(::mlir::Attribute tablegen_opaque_val, ::mlir::StringAttr identifier) const {
+return ::mlir::detail::filterEntryForIdentifier((tablegen_opaque_val.cast<ConcreteAttr>()).getEntries(),
+                                                        identifier);
+}
+template<typename ConcreteModel, typename ConcreteAttr>
+::mlir::LogicalResult detail::DataLayoutSpecInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteAttr>::verifySpec(::mlir::Attribute tablegen_opaque_val, ::mlir::Location loc) const {
+return ::mlir::detail::verifyDataLayoutSpec((tablegen_opaque_val.cast<ConcreteAttr>()), loc);
+}
+} // namespace mlir

--- a/mlir/include/mlir/Interfaces/DataLayoutOpInterface.h.inc
+++ b/mlir/include/mlir/Interfaces/DataLayoutOpInterface.h.inc
@@ -1,0 +1,161 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class DataLayoutOpInterface;
+namespace detail {
+struct DataLayoutOpInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::DataLayoutSpecInterface (*getDataLayoutSpec)(const Concept *impl, ::mlir::Operation *);
+    unsigned (*getTypeSize)(::mlir::Type, const ::mlir::DataLayout &, ::mlir::DataLayoutEntryListRef);
+    unsigned (*getTypeSizeInBits)(::mlir::Type, const ::mlir::DataLayout &, ::mlir::DataLayoutEntryListRef);
+    unsigned (*getTypeABIAlignment)(::mlir::Type, const ::mlir::DataLayout &, ::mlir::DataLayoutEntryListRef);
+    unsigned (*getTypePreferredAlignment)(::mlir::Type, const ::mlir::DataLayout &, ::mlir::DataLayoutEntryListRef);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::DataLayoutOpInterface;
+    Model() : Concept{getDataLayoutSpec, getTypeSize, getTypeSizeInBits, getTypeABIAlignment, getTypePreferredAlignment} {}
+
+    static inline ::mlir::DataLayoutSpecInterface getDataLayoutSpec(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline unsigned getTypeSize(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getTypeSizeInBits(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getTypeABIAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getTypePreferredAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::DataLayoutOpInterface;
+    FallbackModel() : Concept{getDataLayoutSpec, getTypeSize, getTypeSizeInBits, getTypeABIAlignment, getTypePreferredAlignment} {}
+
+    static inline ::mlir::DataLayoutSpecInterface getDataLayoutSpec(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+    static inline unsigned getTypeSize(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getTypeSizeInBits(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getTypeABIAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getTypePreferredAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+    static unsigned getTypeSize(::mlir::Type type, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static unsigned getTypeSizeInBits(::mlir::Type type, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static unsigned getTypeABIAlignment(::mlir::Type type, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static unsigned getTypePreferredAlignment(::mlir::Type type, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params);
+  };
+};template <typename ConcreteOp>
+struct DataLayoutOpInterfaceTrait;
+
+} // namespace detail
+class DataLayoutOpInterface : public ::mlir::OpInterface<DataLayoutOpInterface, detail::DataLayoutOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<DataLayoutOpInterface, detail::DataLayoutOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::DataLayoutOpInterfaceTrait<ConcreteOp> {};
+  /// Returns the data layout specification for this op, or null if it does not exist.
+  ::mlir::DataLayoutSpecInterface getDataLayoutSpec();
+  /// Returns the size of the given type computed using the relevant entries. The data layout object can be used for recursive queries.
+  unsigned getTypeSize(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+  /// Returns the size of the given type in bits computed using the relevant entries. The data layout object can be used for recursive queries.
+  unsigned getTypeSizeInBits(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+  /// Returns the alignment required by the ABI for the given type computed using the relevant entries. The data layout object can be used for recursive queries.
+  unsigned getTypeABIAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+  /// Returns the alignment preferred by the given type computed using the relevant entries. The data layoutobject can be used for recursive queries.
+  unsigned getTypePreferredAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct DataLayoutOpInterfaceTrait : public ::mlir::OpInterface<DataLayoutOpInterface, detail::DataLayoutOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+    /// Returns the size of the given type computed using the relevant entries. The data layout object can be used for recursive queries.
+    static unsigned getTypeSize(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+      unsigned bits = ConcreteOp::getTypeSizeInBits(type, dataLayout, params);
+        return ::llvm::divideCeil(bits, 8);
+    }
+    /// Returns the size of the given type in bits computed using the relevant entries. The data layout object can be used for recursive queries.
+    static unsigned getTypeSizeInBits(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+      return ::mlir::detail::getDefaultTypeSizeInBits(type, dataLayout,
+                                                        params);
+    }
+    /// Returns the alignment required by the ABI for the given type computed using the relevant entries. The data layout object can be used for recursive queries.
+    static unsigned getTypeABIAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+      return ::mlir::detail::getDefaultABIAlignment(type, dataLayout, params);
+    }
+    /// Returns the alignment preferred by the given type computed using the relevant entries. The data layoutobject can be used for recursive queries.
+    static unsigned getTypePreferredAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+      return ::mlir::detail::getDefaultPreferredAlignment(type, dataLayout,
+                                                            params);
+    }
+    static ::mlir::LogicalResult verifyTrait(::mlir::Operation *op) {
+      return ::mlir::detail::verifyDataLayoutOp(op);
+    }
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::DataLayoutSpecInterface detail::DataLayoutOpInterfaceInterfaceTraits::Model<ConcreteOp>::getDataLayoutSpec(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getDataLayoutSpec();
+}
+template<typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::Model<ConcreteOp>::getTypeSize(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return ConcreteOp::getTypeSize(type, dataLayout, params);
+}
+template<typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::Model<ConcreteOp>::getTypeSizeInBits(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return ConcreteOp::getTypeSizeInBits(type, dataLayout, params);
+}
+template<typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::Model<ConcreteOp>::getTypeABIAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return ConcreteOp::getTypeABIAlignment(type, dataLayout, params);
+}
+template<typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::Model<ConcreteOp>::getTypePreferredAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return ConcreteOp::getTypePreferredAlignment(type, dataLayout, params);
+}
+template<typename ConcreteOp>
+::mlir::DataLayoutSpecInterface detail::DataLayoutOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getDataLayoutSpec(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getDataLayoutSpec(tablegen_opaque_val);
+}
+template<typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getTypeSize(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return ConcreteOp::getTypeSize(type, dataLayout, params);
+}
+template<typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getTypeSizeInBits(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return ConcreteOp::getTypeSizeInBits(type, dataLayout, params);
+}
+template<typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getTypeABIAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return ConcreteOp::getTypeABIAlignment(type, dataLayout, params);
+}
+template<typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getTypePreferredAlignment(::mlir::Type type, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return ConcreteOp::getTypePreferredAlignment(type, dataLayout, params);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getTypeSize(::mlir::Type type, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) {
+unsigned bits = ConcreteOp::getTypeSizeInBits(type, dataLayout, params);
+        return ::llvm::divideCeil(bits, 8);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getTypeSizeInBits(::mlir::Type type, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) {
+return ::mlir::detail::getDefaultTypeSizeInBits(type, dataLayout,
+                                                        params);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getTypeABIAlignment(::mlir::Type type, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) {
+return ::mlir::detail::getDefaultABIAlignment(type, dataLayout, params);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+unsigned detail::DataLayoutOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::getTypePreferredAlignment(::mlir::Type type, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) {
+return ::mlir::detail::getDefaultPreferredAlignment(type, dataLayout,
+                                                            params);
+}
+} // namespace mlir

--- a/mlir/include/mlir/Interfaces/DataLayoutTypeInterface.h.inc
+++ b/mlir/include/mlir/Interfaces/DataLayoutTypeInterface.h.inc
@@ -1,0 +1,158 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class DataLayoutTypeInterface;
+namespace detail {
+struct DataLayoutTypeInterfaceInterfaceTraits {
+  struct Concept {
+    unsigned (*getTypeSize)(const Concept *impl, ::mlir::Type , const ::mlir::DataLayout &, ::mlir::DataLayoutEntryListRef);
+    unsigned (*getTypeSizeInBits)(const Concept *impl, ::mlir::Type , const ::mlir::DataLayout &, ::mlir::DataLayoutEntryListRef);
+    unsigned (*getABIAlignment)(const Concept *impl, ::mlir::Type , const ::mlir::DataLayout &, ::mlir::DataLayoutEntryListRef);
+    unsigned (*getPreferredAlignment)(const Concept *impl, ::mlir::Type , const ::mlir::DataLayout &, ::mlir::DataLayoutEntryListRef);
+    bool (*areCompatible)(const Concept *impl, ::mlir::Type , ::mlir::DataLayoutEntryListRef, ::mlir::DataLayoutEntryListRef);
+    ::mlir::LogicalResult (*verifyEntries)(const Concept *impl, ::mlir::Type , ::mlir::DataLayoutEntryListRef, ::mlir::Location);
+  };
+  template<typename ConcreteType>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::DataLayoutTypeInterface;
+    Model() : Concept{getTypeSize, getTypeSizeInBits, getABIAlignment, getPreferredAlignment, areCompatible, verifyEntries} {}
+
+    static inline unsigned getTypeSize(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getTypeSizeInBits(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getABIAlignment(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getPreferredAlignment(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline bool areCompatible(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout);
+    static inline ::mlir::LogicalResult verifyEntries(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc);
+  };
+  template<typename ConcreteType>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::DataLayoutTypeInterface;
+    FallbackModel() : Concept{getTypeSize, getTypeSizeInBits, getABIAlignment, getPreferredAlignment, areCompatible, verifyEntries} {}
+
+    static inline unsigned getTypeSize(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getTypeSizeInBits(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getABIAlignment(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline unsigned getPreferredAlignment(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params);
+    static inline bool areCompatible(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout);
+    static inline ::mlir::LogicalResult verifyEntries(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc);
+  };
+  template<typename ConcreteModel, typename ConcreteType>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteType;
+    unsigned getTypeSize(::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+    bool areCompatible(::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout) const;
+    ::mlir::LogicalResult verifyEntries(::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc) const;
+  };
+};template <typename ConcreteType>
+struct DataLayoutTypeInterfaceTrait;
+
+} // namespace detail
+class DataLayoutTypeInterface : public ::mlir::TypeInterface<DataLayoutTypeInterface, detail::DataLayoutTypeInterfaceInterfaceTraits> {
+public:
+  using ::mlir::TypeInterface<DataLayoutTypeInterface, detail::DataLayoutTypeInterfaceInterfaceTraits>::TypeInterface;
+  template <typename ConcreteType>
+  struct Trait : public detail::DataLayoutTypeInterfaceTrait<ConcreteType> {};
+  /// Returns the size of this type in bytes.
+  unsigned getTypeSize(const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  /// Returns the size of this type in bits.
+  unsigned getTypeSizeInBits(const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  /// Returns the ABI-required alignment for this type, in bytes
+  unsigned getABIAlignment(const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  /// Returns the preferred alignment for this type, in bytes.
+  unsigned getPreferredAlignment(const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) const;
+  /// Returns true if the two lists of entries are compatible, that is, that `newLayout` spec entries can be nested in an op with `oldLayout` spec entries.
+  bool areCompatible(::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout) const;
+  /// Verifies that the given list of entries is valid for this type.
+  ::mlir::LogicalResult verifyEntries(::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc) const;
+};
+namespace detail {
+  template <typename ConcreteType>
+  struct DataLayoutTypeInterfaceTrait : public ::mlir::TypeInterface<DataLayoutTypeInterface, detail::DataLayoutTypeInterfaceInterfaceTraits>::Trait<ConcreteType> {
+    /// Returns the size of this type in bytes.
+    unsigned getTypeSize(const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) const {
+      unsigned bits = (*static_cast<const ConcreteType *>(this)).getTypeSizeInBits(dataLayout, params);
+        return ::llvm::divideCeil(bits, 8);
+    }
+    /// Returns true if the two lists of entries are compatible, that is, that `newLayout` spec entries can be nested in an op with `oldLayout` spec entries.
+    bool areCompatible(::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout) const {
+      return true;
+    }
+    /// Verifies that the given list of entries is valid for this type.
+    ::mlir::LogicalResult verifyEntries(::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc) const {
+      return ::mlir::success();
+    }
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::Model<ConcreteType>::getTypeSize(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).getTypeSize(dataLayout, params);
+}
+template<typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::Model<ConcreteType>::getTypeSizeInBits(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).getTypeSizeInBits(dataLayout, params);
+}
+template<typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::Model<ConcreteType>::getABIAlignment(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).getABIAlignment(dataLayout, params);
+}
+template<typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::Model<ConcreteType>::getPreferredAlignment(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).getPreferredAlignment(dataLayout, params);
+}
+template<typename ConcreteType>
+bool detail::DataLayoutTypeInterfaceInterfaceTraits::Model<ConcreteType>::areCompatible(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).areCompatible(oldLayout, newLayout);
+}
+template<typename ConcreteType>
+::mlir::LogicalResult detail::DataLayoutTypeInterfaceInterfaceTraits::Model<ConcreteType>::verifyEntries(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc) {
+  return (tablegen_opaque_val.cast<ConcreteType>()).verifyEntries(entries, loc);
+}
+template<typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::getTypeSize(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return static_cast<const ConcreteType *>(impl)->getTypeSize(tablegen_opaque_val, dataLayout, params);
+}
+template<typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::getTypeSizeInBits(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return static_cast<const ConcreteType *>(impl)->getTypeSizeInBits(tablegen_opaque_val, dataLayout, params);
+}
+template<typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::getABIAlignment(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return static_cast<const ConcreteType *>(impl)->getABIAlignment(tablegen_opaque_val, dataLayout, params);
+}
+template<typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::getPreferredAlignment(const Concept *impl, ::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout & dataLayout, ::mlir::DataLayoutEntryListRef params) {
+  return static_cast<const ConcreteType *>(impl)->getPreferredAlignment(tablegen_opaque_val, dataLayout, params);
+}
+template<typename ConcreteType>
+bool detail::DataLayoutTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::areCompatible(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout) {
+  return static_cast<const ConcreteType *>(impl)->areCompatible(tablegen_opaque_val, oldLayout, newLayout);
+}
+template<typename ConcreteType>
+::mlir::LogicalResult detail::DataLayoutTypeInterfaceInterfaceTraits::FallbackModel<ConcreteType>::verifyEntries(const Concept *impl, ::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc) {
+  return static_cast<const ConcreteType *>(impl)->verifyEntries(tablegen_opaque_val, entries, loc);
+}
+template<typename ConcreteModel, typename ConcreteType>
+unsigned detail::DataLayoutTypeInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteType>::getTypeSize(::mlir::Type tablegen_opaque_val, const ::mlir::DataLayout &dataLayout, ::mlir::DataLayoutEntryListRef params) const {
+unsigned bits = (tablegen_opaque_val.cast<ConcreteType>()).getTypeSizeInBits(dataLayout, params);
+        return ::llvm::divideCeil(bits, 8);
+}
+template<typename ConcreteModel, typename ConcreteType>
+bool detail::DataLayoutTypeInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteType>::areCompatible(::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef oldLayout, ::mlir::DataLayoutEntryListRef newLayout) const {
+return true;
+}
+template<typename ConcreteModel, typename ConcreteType>
+::mlir::LogicalResult detail::DataLayoutTypeInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteType>::verifyEntries(::mlir::Type tablegen_opaque_val, ::mlir::DataLayoutEntryListRef entries, ::mlir::Location loc) const {
+return ::mlir::success();
+}
+} // namespace mlir

--- a/mlir/include/mlir/Interfaces/InferTypeOpInterface.h.inc
+++ b/mlir/include/mlir/Interfaces/InferTypeOpInterface.h.inc
@@ -1,0 +1,383 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class InferShapedTypeOpInterface;
+namespace detail {
+struct InferShapedTypeOpInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::LogicalResult (*inferReturnTypeComponents)(::mlir::MLIRContext*, ::std::optional<::mlir::Location>, ::mlir::ValueShapeRange, ::mlir::DictionaryAttr, ::mlir::RegionRange, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>&);
+    ::mlir::LogicalResult (*reifyReturnTypeShapes)(const Concept *impl, ::mlir::Operation *, ::mlir::OpBuilder&, ::mlir::ValueRange, ::llvm::SmallVectorImpl<::mlir::Value> &);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::InferShapedTypeOpInterface;
+    Model() : Concept{inferReturnTypeComponents, reifyReturnTypeShapes} {}
+
+    static inline ::mlir::LogicalResult inferReturnTypeComponents(::mlir::MLIRContext* context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>& inferredReturnShapes);
+    static inline ::mlir::LogicalResult reifyReturnTypeShapes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder& builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> & reifiedReturnShapes);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::InferShapedTypeOpInterface;
+    FallbackModel() : Concept{inferReturnTypeComponents, reifyReturnTypeShapes} {}
+
+    static inline ::mlir::LogicalResult inferReturnTypeComponents(::mlir::MLIRContext* context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>& inferredReturnShapes);
+    static inline ::mlir::LogicalResult reifyReturnTypeShapes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder& builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> & reifiedReturnShapes);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+    static ::mlir::LogicalResult inferReturnTypeComponents(::mlir::MLIRContext*context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>&inferredReturnShapes);
+    ::mlir::LogicalResult reifyReturnTypeShapes(::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder&builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> &reifiedReturnShapes) const;
+  };
+};template <typename ConcreteOp>
+struct InferShapedTypeOpInterfaceTrait;
+
+} // namespace detail
+class InferShapedTypeOpInterface : public ::mlir::OpInterface<InferShapedTypeOpInterface, detail::InferShapedTypeOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<InferShapedTypeOpInterface, detail::InferShapedTypeOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::InferShapedTypeOpInterfaceTrait<ConcreteOp> {};
+  /// Infer the components of return type of shape containter.
+  /// 
+  ///       The method takes an optional location which, if set, will be used to
+  ///       report errors on. The operands and attributes correspond to those with
+  ///       which an Operation would be created (e.g., as used in Operation::create)
+  ///       and the regions of the op.
+  /// 
+  ///       Unknown (e.g., unranked) shape and nullptrs for element type and attribute
+  ///       may be returned by this function while returning success. E.g., partial
+  ///       population of components is not error condition.
+  ::mlir::LogicalResult inferReturnTypeComponents(::mlir::MLIRContext* context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>& inferredReturnShapes);
+  /// Reify the shape computation for the operation.
+  /// 
+  ///       Insert operations using the given OpBuilder that computes the
+  ///       result shape. This interface is supposed to be workable during dialect
+  ///       conversion (e.g. convert from tensor world to buffer world),
+  ///       where `getOperand` may be invalid. For example, some ops (e.g.
+  ///       dynamic_reshape(input, target_shape)) may depend on their operands
+  ///       to calculate the result shape. When the `matchAndRewrite ` method
+  ///       of a conversion pattern is called, the operands of the op to convert
+  ///       may have been converted into other types, which makes it invalid to
+  ///       call the `getOperand` method of such op directly inside the
+  ///       conversion pattern.  To solve this problem, this interface follows
+  ///       the design of the conversion pattern, that is, accepting passed in
+  ///       operands to avoid calling `getOperand` directly inside the interface
+  ///       implementation.
+  ::mlir::LogicalResult reifyReturnTypeShapes(::mlir::OpBuilder& builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> & reifiedReturnShapes);
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct InferShapedTypeOpInterfaceTrait : public ::mlir::OpInterface<InferShapedTypeOpInterface, detail::InferShapedTypeOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+    /// Infer the components of return type of shape containter.
+    /// 
+    ///       The method takes an optional location which, if set, will be used to
+    ///       report errors on. The operands and attributes correspond to those with
+    ///       which an Operation would be created (e.g., as used in Operation::create)
+    ///       and the regions of the op.
+    /// 
+    ///       Unknown (e.g., unranked) shape and nullptrs for element type and attribute
+    ///       may be returned by this function while returning success. E.g., partial
+    ///       population of components is not error condition.
+    static ::mlir::LogicalResult inferReturnTypeComponents(::mlir::MLIRContext* context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>& inferredReturnShapes) {
+      return ::mlir::failure();
+    }
+    /// Reify the shape computation for the operation.
+    /// 
+    ///       Insert operations using the given OpBuilder that computes the
+    ///       result shape. This interface is supposed to be workable during dialect
+    ///       conversion (e.g. convert from tensor world to buffer world),
+    ///       where `getOperand` may be invalid. For example, some ops (e.g.
+    ///       dynamic_reshape(input, target_shape)) may depend on their operands
+    ///       to calculate the result shape. When the `matchAndRewrite ` method
+    ///       of a conversion pattern is called, the operands of the op to convert
+    ///       may have been converted into other types, which makes it invalid to
+    ///       call the `getOperand` method of such op directly inside the
+    ///       conversion pattern.  To solve this problem, this interface follows
+    ///       the design of the conversion pattern, that is, accepting passed in
+    ///       operands to avoid calling `getOperand` directly inside the interface
+    ///       implementation.
+    ::mlir::LogicalResult reifyReturnTypeShapes(::mlir::OpBuilder& builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> & reifiedReturnShapes) {
+      return ::mlir::failure();
+    }
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class InferTypeOpInterface;
+namespace detail {
+struct InferTypeOpInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::LogicalResult (*inferReturnTypes)(::mlir::MLIRContext *, ::std::optional<::mlir::Location>, ::mlir::ValueRange, ::mlir::DictionaryAttr, ::mlir::RegionRange, ::llvm::SmallVectorImpl<::mlir::Type>&);
+    ::mlir::LogicalResult (*refineReturnTypes)(::mlir::MLIRContext *, ::std::optional<::mlir::Location>, ::mlir::ValueRange, ::mlir::DictionaryAttr, ::mlir::RegionRange, ::llvm::SmallVectorImpl<::mlir::Type>&);
+    bool (*isCompatibleReturnTypes)(::mlir::TypeRange, ::mlir::TypeRange);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::InferTypeOpInterface;
+    Model() : Concept{inferReturnTypes, refineReturnTypes, isCompatibleReturnTypes} {}
+
+    static inline ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& inferredReturnTypes);
+    static inline ::mlir::LogicalResult refineReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& returnTypes);
+    static inline bool isCompatibleReturnTypes(::mlir::TypeRange lhs, ::mlir::TypeRange rhs);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::InferTypeOpInterface;
+    FallbackModel() : Concept{inferReturnTypes, refineReturnTypes, isCompatibleReturnTypes} {}
+
+    static inline ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& inferredReturnTypes);
+    static inline ::mlir::LogicalResult refineReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& returnTypes);
+    static inline bool isCompatibleReturnTypes(::mlir::TypeRange lhs, ::mlir::TypeRange rhs);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+    static ::mlir::LogicalResult refineReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&returnTypes);
+    static bool isCompatibleReturnTypes(::mlir::TypeRange lhs, ::mlir::TypeRange rhs);
+  };
+};template <typename ConcreteOp>
+struct InferTypeOpInterfaceTrait;
+
+} // namespace detail
+class InferTypeOpInterface : public ::mlir::OpInterface<InferTypeOpInterface, detail::InferTypeOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<InferTypeOpInterface, detail::InferTypeOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::InferTypeOpInterfaceTrait<ConcreteOp> {};
+  /// Infer the return types that an op would generate.
+  /// 
+  ///       The method takes an optional location which, if set, will be used to
+  ///       report errors on. The operands and attributes correspond to those with
+  ///       which an Operation would be created (e.g., as used in Operation::create)
+  ///       and the regions of the op. Be aware that this method is supposed to be
+  ///       called with valid arguments, e.g., operands are verified, or it may result
+  ///       in an undefined behavior.
+  ::mlir::LogicalResult inferReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& inferredReturnTypes);
+  /// Refine the return types that an op would generate.
+  /// 
+  ///       This method computes the return types as `inferReturnTypes` does but
+  ///       additionally takes the existing result types as input. The existing
+  ///       result types can be checked as part of inference to provide more
+  ///       op-specific error messages as well as part of inference to merge
+  ///       additional information, attributes, during inference. It is called during
+  ///       verification for ops implementing this trait with default behavior
+  ///       reporting mismatch with current and inferred types printed.
+  /// 
+  ///       The operands and attributes correspond to those with which an Operation
+  ///       would be created (e.g., as used in Operation::create) and the regions of
+  ///       the op. The method takes an optional location which, if set, will be used
+  ///       to report errors on.
+  /// 
+  ///       The return types may be elided or specific elements be null for elements
+  ///       that should just be returned but not verified.
+  /// 
+  ///       Be aware that this method is supposed to be called with valid arguments,
+  ///       e.g., operands are verified, or it may result in an undefined behavior.
+  ::mlir::LogicalResult refineReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& returnTypes);
+  /// Returns whether two array of types are compatible result types for an op.
+  bool isCompatibleReturnTypes(::mlir::TypeRange lhs, ::mlir::TypeRange rhs);
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct InferTypeOpInterfaceTrait : public ::mlir::OpInterface<InferTypeOpInterface, detail::InferTypeOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+    /// Refine the return types that an op would generate.
+    /// 
+    ///       This method computes the return types as `inferReturnTypes` does but
+    ///       additionally takes the existing result types as input. The existing
+    ///       result types can be checked as part of inference to provide more
+    ///       op-specific error messages as well as part of inference to merge
+    ///       additional information, attributes, during inference. It is called during
+    ///       verification for ops implementing this trait with default behavior
+    ///       reporting mismatch with current and inferred types printed.
+    /// 
+    ///       The operands and attributes correspond to those with which an Operation
+    ///       would be created (e.g., as used in Operation::create) and the regions of
+    ///       the op. The method takes an optional location which, if set, will be used
+    ///       to report errors on.
+    /// 
+    ///       The return types may be elided or specific elements be null for elements
+    ///       that should just be returned but not verified.
+    /// 
+    ///       Be aware that this method is supposed to be called with valid arguments,
+    ///       e.g., operands are verified, or it may result in an undefined behavior.
+    static ::mlir::LogicalResult refineReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& returnTypes) {
+      llvm::SmallVector<Type, 4> inferredReturnTypes;
+          if (failed(ConcreteOp::inferReturnTypes(context, location, operands,
+                                                  attributes, regions,
+                                                  inferredReturnTypes)))
+            return failure();
+          if (!ConcreteOp::isCompatibleReturnTypes(inferredReturnTypes,
+                                                   returnTypes)) {
+            return emitOptionalError(
+                location, "'", ConcreteOp::getOperationName(),
+                "' op inferred type(s) ", inferredReturnTypes,
+                " are incompatible with return type(s) of operation ",
+                returnTypes);
+          }
+          return success();
+    }
+    /// Returns whether two array of types are compatible result types for an op.
+    static bool isCompatibleReturnTypes(::mlir::TypeRange lhs, ::mlir::TypeRange rhs) {
+      /// Returns whether two arrays are equal as strongest check for
+        /// compatibility by default.
+        return lhs == rhs;
+    }
+    static ::mlir::LogicalResult verifyRegionTrait(::mlir::Operation *op) {
+      return detail::verifyInferredResultTypes(op);
+    }
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class ReifyRankedShapedTypeOpInterface;
+namespace detail {
+struct ReifyRankedShapedTypeOpInterfaceInterfaceTraits {
+  struct Concept {
+    ::mlir::LogicalResult (*reifyResultShapes)(const Concept *impl, ::mlir::Operation *, ::mlir::OpBuilder &, ::mlir::ReifiedRankedShapedTypeDims &);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::ReifyRankedShapedTypeOpInterface;
+    Model() : Concept{reifyResultShapes} {}
+
+    static inline ::mlir::LogicalResult reifyResultShapes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder & builder, ::mlir::ReifiedRankedShapedTypeDims & reifiedReturnShapes);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::ReifyRankedShapedTypeOpInterface;
+    FallbackModel() : Concept{reifyResultShapes} {}
+
+    static inline ::mlir::LogicalResult reifyResultShapes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder & builder, ::mlir::ReifiedRankedShapedTypeDims & reifiedReturnShapes);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+  };
+};template <typename ConcreteOp>
+struct ReifyRankedShapedTypeOpInterfaceTrait;
+
+} // namespace detail
+class ReifyRankedShapedTypeOpInterface : public ::mlir::OpInterface<ReifyRankedShapedTypeOpInterface, detail::ReifyRankedShapedTypeOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<ReifyRankedShapedTypeOpInterface, detail::ReifyRankedShapedTypeOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::ReifyRankedShapedTypeOpInterfaceTrait<ConcreteOp> {};
+  /// Reify the shape of the result of an operation (typically in
+  /// terms of shape of its operands)
+  /// 
+  /// Insert operations using the given `OpBuilder` that computes
+  /// the result shape. The `reifiedReturnShapes` is expected to be
+  /// populated with as many vectors as the number of results of the
+  /// op. Each of these vectors is expected to be of size equal to
+  /// rank of the corresponding result. If the shape of a particular
+  /// result cannot be computed it must be empty.
+  ::mlir::LogicalResult reifyResultShapes(::mlir::OpBuilder & builder, ::mlir::ReifiedRankedShapedTypeDims & reifiedReturnShapes);
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct ReifyRankedShapedTypeOpInterfaceTrait : public ::mlir::OpInterface<ReifyRankedShapedTypeOpInterface, detail::ReifyRankedShapedTypeOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::InferShapedTypeOpInterfaceInterfaceTraits::Model<ConcreteOp>::inferReturnTypeComponents(::mlir::MLIRContext* context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>& inferredReturnShapes) {
+  return ConcreteOp::inferReturnTypeComponents(context, location, operands, attributes, regions, inferredReturnShapes);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::InferShapedTypeOpInterfaceInterfaceTraits::Model<ConcreteOp>::reifyReturnTypeShapes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder& builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> & reifiedReturnShapes) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).reifyReturnTypeShapes(builder, operands, reifiedReturnShapes);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::InferShapedTypeOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::inferReturnTypeComponents(::mlir::MLIRContext* context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>& inferredReturnShapes) {
+  return ConcreteOp::inferReturnTypeComponents(context, location, operands, attributes, regions, inferredReturnShapes);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::InferShapedTypeOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::reifyReturnTypeShapes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder& builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> & reifiedReturnShapes) {
+  return static_cast<const ConcreteOp *>(impl)->reifyReturnTypeShapes(tablegen_opaque_val, builder, operands, reifiedReturnShapes);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::mlir::LogicalResult detail::InferShapedTypeOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::inferReturnTypeComponents(::mlir::MLIRContext*context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>&inferredReturnShapes) {
+return ::mlir::failure();
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::mlir::LogicalResult detail::InferShapedTypeOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::reifyReturnTypeShapes(::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder&builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> &reifiedReturnShapes) const {
+return ::mlir::failure();
+}
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::InferTypeOpInterfaceInterfaceTraits::Model<ConcreteOp>::inferReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& inferredReturnTypes) {
+  return ConcreteOp::inferReturnTypes(context, location, operands, attributes, regions, inferredReturnTypes);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::InferTypeOpInterfaceInterfaceTraits::Model<ConcreteOp>::refineReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& returnTypes) {
+  return ConcreteOp::refineReturnTypes(context, location, operands, attributes, regions, returnTypes);
+}
+template<typename ConcreteOp>
+bool detail::InferTypeOpInterfaceInterfaceTraits::Model<ConcreteOp>::isCompatibleReturnTypes(::mlir::TypeRange lhs, ::mlir::TypeRange rhs) {
+  return ConcreteOp::isCompatibleReturnTypes(lhs, rhs);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::InferTypeOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::inferReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& inferredReturnTypes) {
+  return ConcreteOp::inferReturnTypes(context, location, operands, attributes, regions, inferredReturnTypes);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::InferTypeOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::refineReturnTypes(::mlir::MLIRContext * context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>& returnTypes) {
+  return ConcreteOp::refineReturnTypes(context, location, operands, attributes, regions, returnTypes);
+}
+template<typename ConcreteOp>
+bool detail::InferTypeOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::isCompatibleReturnTypes(::mlir::TypeRange lhs, ::mlir::TypeRange rhs) {
+  return ConcreteOp::isCompatibleReturnTypes(lhs, rhs);
+}
+template<typename ConcreteModel, typename ConcreteOp>
+::mlir::LogicalResult detail::InferTypeOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::refineReturnTypes(::mlir::MLIRContext *context, ::std::optional<::mlir::Location> location, ::mlir::ValueRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::Type>&returnTypes) {
+llvm::SmallVector<Type, 4> inferredReturnTypes;
+          if (failed(ConcreteOp::inferReturnTypes(context, location, operands,
+                                                  attributes, regions,
+                                                  inferredReturnTypes)))
+            return failure();
+          if (!ConcreteOp::isCompatibleReturnTypes(inferredReturnTypes,
+                                                   returnTypes)) {
+            return emitOptionalError(
+                location, "'", ConcreteOp::getOperationName(),
+                "' op inferred type(s) ", inferredReturnTypes,
+                " are incompatible with return type(s) of operation ",
+                returnTypes);
+          }
+          return success();
+}
+template<typename ConcreteModel, typename ConcreteOp>
+bool detail::InferTypeOpInterfaceInterfaceTraits::ExternalModel<ConcreteModel, ConcreteOp>::isCompatibleReturnTypes(::mlir::TypeRange lhs, ::mlir::TypeRange rhs) {
+/// Returns whether two arrays are equal as strongest check for
+        /// compatibility by default.
+        return lhs == rhs;
+}
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::ReifyRankedShapedTypeOpInterfaceInterfaceTraits::Model<ConcreteOp>::reifyResultShapes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder & builder, ::mlir::ReifiedRankedShapedTypeDims & reifiedReturnShapes) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).reifyResultShapes(builder, reifiedReturnShapes);
+}
+template<typename ConcreteOp>
+::mlir::LogicalResult detail::ReifyRankedShapedTypeOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::reifyResultShapes(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::mlir::OpBuilder & builder, ::mlir::ReifiedRankedShapedTypeDims & reifiedReturnShapes) {
+  return static_cast<const ConcreteOp *>(impl)->reifyResultShapes(tablegen_opaque_val, builder, reifiedReturnShapes);
+}
+} // namespace mlir

--- a/mlir/include/mlir/Interfaces/SideEffectInterfaces.h.inc
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaces.h.inc
@@ -1,0 +1,206 @@
+/*===- TableGen'erated file -------------------------------------*- C++ -*-===*\
+|*                                                                            *|
+|* Interface Declarations                                                     *|
+|*                                                                            *|
+|* Automatically generated file, do not edit!                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+namespace mlir {
+class ConditionallySpeculatable;
+namespace detail {
+struct ConditionallySpeculatableInterfaceTraits {
+  struct Concept {
+    ::mlir::Speculation::Speculatability (*getSpeculatability)(const Concept *impl, ::mlir::Operation *);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::ConditionallySpeculatable;
+    Model() : Concept{getSpeculatability} {}
+
+    static inline ::mlir::Speculation::Speculatability getSpeculatability(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::ConditionallySpeculatable;
+    FallbackModel() : Concept{getSpeculatability} {}
+
+    static inline ::mlir::Speculation::Speculatability getSpeculatability(const Concept *impl, ::mlir::Operation *tablegen_opaque_val);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+  };
+};template <typename ConcreteOp>
+struct ConditionallySpeculatableTrait;
+
+} // namespace detail
+class ConditionallySpeculatable : public ::mlir::OpInterface<ConditionallySpeculatable, detail::ConditionallySpeculatableInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<ConditionallySpeculatable, detail::ConditionallySpeculatableInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::ConditionallySpeculatableTrait<ConcreteOp> {};
+  /// Returns value indicating whether the specific operation in question can
+  /// be speculatively executed.  Please see the documentation on the
+  /// Speculatability enum to know how to interpret the return value.
+  ::mlir::Speculation::Speculatability getSpeculatability();
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct ConditionallySpeculatableTrait : public ::mlir::OpInterface<ConditionallySpeculatable, detail::ConditionallySpeculatableInterfaceTraits>::Trait<ConcreteOp> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+class MemoryEffectOpInterface;
+namespace detail {
+struct MemoryEffectOpInterfaceInterfaceTraits {
+  struct Concept {
+    void (*getEffects)(const Concept *impl, ::mlir::Operation *, ::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &);
+  };
+  template<typename ConcreteOp>
+  class Model : public Concept {
+  public:
+    using Interface = ::mlir::MemoryEffectOpInterface;
+    Model() : Concept{getEffects} {}
+
+    static inline void getEffects(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> & effects);
+  };
+  template<typename ConcreteOp>
+  class FallbackModel : public Concept {
+  public:
+    using Interface = ::mlir::MemoryEffectOpInterface;
+    FallbackModel() : Concept{getEffects} {}
+
+    static inline void getEffects(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> & effects);
+  };
+  template<typename ConcreteModel, typename ConcreteOp>
+  class ExternalModel : public FallbackModel<ConcreteModel> {
+  public:
+    using ConcreteEntity = ConcreteOp;
+  };
+};template <typename ConcreteOp>
+struct MemoryEffectOpInterfaceTrait;
+
+} // namespace detail
+class MemoryEffectOpInterface : public ::mlir::OpInterface<MemoryEffectOpInterface, detail::MemoryEffectOpInterfaceInterfaceTraits> {
+public:
+  using ::mlir::OpInterface<MemoryEffectOpInterface, detail::MemoryEffectOpInterfaceInterfaceTraits>::OpInterface;
+  template <typename ConcreteOp>
+  struct Trait : public detail::MemoryEffectOpInterfaceTrait<ConcreteOp> {};
+  /// Collects all of the operation's effects into `effects`.
+  void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> & effects);
+
+    /// Collect all of the effect instances that correspond to the given
+    /// `Effect` and place them in 'effects'.
+    template <typename Effect> void getEffects(
+      SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+                                              ::mlir::MemoryEffects::Effect>> &effects) {
+      getEffects(effects);
+      llvm::erase_if(effects, [&](auto &it) {
+        return !llvm::isa<Effect>(it.getEffect());
+      });
+    }
+
+    /// Returns true if this operation exhibits the given effect.
+    template <typename Effect> bool hasEffect() {
+      SmallVector<SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>, 4> effects;
+      getEffects(effects);
+      return llvm::any_of(effects, [](const auto &it) {
+        return llvm::isa<Effect>(it.getEffect());
+      });
+    }
+
+    /// Returns true if this operation only has the given effect.
+    template <typename Effect> bool onlyHasEffect() {
+      SmallVector<SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>, 4> effects;
+      getEffects(effects);
+      return !effects.empty() && llvm::all_of(effects, [](const auto &it) {
+        return isa<Effect>(it.getEffect());
+      });
+    }
+
+    /// Returns true if this operation has no effects.
+    bool hasNoEffect() {
+      SmallVector<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>, 4> effects;
+      getEffects(effects);
+      return effects.empty();
+    }
+
+    /// Collect all of the effect instances that operate on the provided value
+    /// and place them in 'effects'.
+    void getEffectsOnValue(::mlir::Value value,
+              llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+              ::mlir::MemoryEffects::Effect>> & effects) {
+      getEffects(effects);
+      llvm::erase_if(effects, [&](auto &it) { return it.getValue() != value; });
+    }
+
+    /// Return the effect of the given type `Effect` that is applied to the
+    /// given value, or std::nullopt if no effect exists.
+    template <typename Effect>
+    ::std::optional<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>>
+    getEffectOnValue(::mlir::Value value) {
+      llvm::SmallVector<::mlir::SideEffects::EffectInstance<
+              ::mlir::MemoryEffects::Effect>, 4> effects;
+      getEffects(effects);
+      auto it = llvm::find_if(effects, [&](auto &it) {
+        return isa<Effect>(it.getEffect()) && it.getValue() == value;
+      });
+      if (it == effects.end())
+        return std::nullopt;
+      return *it;
+    }
+
+    /// Collect all of the effect instances that operate on the provided symbol
+    /// reference and place them in 'effects'.
+    void getEffectsOnSymbol(::mlir::SymbolRefAttr value,
+              llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+              ::mlir::MemoryEffects::Effect>> & effects) {
+      getEffects(effects);
+      llvm::erase_if(effects, [&](auto &it) {
+        return it.getSymbolRef() != value;
+      });
+    }
+
+    /// Collect all of the effect instances that operate on the provided
+    /// resource and place them in 'effects'.
+    void getEffectsOnResource(::mlir::SideEffects::Resource *resource,
+              llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+              ::mlir::MemoryEffects::Effect>> & effects) {
+      getEffects(effects);
+      llvm::erase_if(effects, [&](auto &it) {
+        return it.getResource() != resource;
+      });
+    }
+  
+};
+namespace detail {
+  template <typename ConcreteOp>
+  struct MemoryEffectOpInterfaceTrait : public ::mlir::OpInterface<MemoryEffectOpInterface, detail::MemoryEffectOpInterfaceInterfaceTraits>::Trait<ConcreteOp> {
+  };
+}// namespace detail
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+::mlir::Speculation::Speculatability detail::ConditionallySpeculatableInterfaceTraits::Model<ConcreteOp>::getSpeculatability(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getSpeculatability();
+}
+template<typename ConcreteOp>
+::mlir::Speculation::Speculatability detail::ConditionallySpeculatableInterfaceTraits::FallbackModel<ConcreteOp>::getSpeculatability(const Concept *impl, ::mlir::Operation *tablegen_opaque_val) {
+  return static_cast<const ConcreteOp *>(impl)->getSpeculatability(tablegen_opaque_val);
+}
+} // namespace mlir
+namespace mlir {
+template<typename ConcreteOp>
+void detail::MemoryEffectOpInterfaceInterfaceTraits::Model<ConcreteOp>::getEffects(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> & effects) {
+  return (llvm::cast<ConcreteOp>(tablegen_opaque_val)).getEffects(effects);
+}
+template<typename ConcreteOp>
+void detail::MemoryEffectOpInterfaceInterfaceTraits::FallbackModel<ConcreteOp>::getEffects(const Concept *impl, ::mlir::Operation *tablegen_opaque_val, ::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> & effects) {
+  return static_cast<const ConcreteOp *>(impl)->getEffects(tablegen_opaque_val, effects);
+}
+} // namespace mlir


### PR DESCRIPTION
Clone the repo, then cd into it, change branch and run

```
docker run -v$(pwd):/app -it silkeh/clang:14-bullseye
```

From docker

```
cd /app
clang --analyze -isystem mlir/include -isystem llvm/include -std=c++17 -c crash.cpp
```

On clang 13 it crashes, on clang 14 it doesn't

```
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.      Program arguments: clang --analyze -isystem mlir/include -isystem llvm/include -std=c++17 -c crash.cpp
1.      <eof> parser at end of file
2.      While analyzing stack: 
        #0 Calling llvm::PointerUnion<llvm::detail::UniqueFunctionBase<mlir::InFlightDiagnostic>::TrivialCallback *, llvm::detail::UniqueFunctionBase<mlir::InFlightDiagnostic>::NonTrivialCallbacks *>::is() at line llvm/include/llvm/ADT/FunctionExtras.h:175:12
        #1 Calling llvm::detail::UniqueFunctionBase<mlir::InFlightDiagnostic>::isTrivialCallback() at line llvm/include/llvm/ADT/FunctionExtras.h:289:10
        #2 Calling llvm::detail::UniqueFunctionBase<mlir::InFlightDiagnostic>::~UniqueFunctionBase()
        #3 Calling llvm::unique_function<mlir::InFlightDiagnostic ()>::~unique_function()
        #4 Calling mlir::detail::StorageUserBase<mlir::LLVM::LLVMVoidType, mlir::Type, mlir::TypeStorage, mlir::detail::TypeUniquer>::get(class mlir::MLIRContext *) at line 6
        #5 Calling mlir::foo::bar(class mlir::MLIRContext *)
3.      llvm/include/llvm/ADT/PointerUnion.h:150:57: Error evaluating statement
4.      llvm/include/llvm/ADT/PointerUnion.h:150:57: Error evaluating statement
 #0 0x00007f1b677d71b1 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/usr/lib/x86_64-linux-gnu/libLLVM-13.so.1+0xde91b1)
 #1 0x00007f1b677d5360 llvm::sys::RunSignalHandlers() (/usr/lib/x86_64-linux-gnu/libLLVM-13.so.1+0xde7360)
 #2 0x00007f1b677d6840 llvm::sys::CleanupOnSignal(unsigned long) (/usr/lib/x86_64-linux-gnu/libLLVM-13.so.1+0xde8840)
 #3 0x00007f1b67715b05 (/usr/lib/x86_64-linux-gnu/libLLVM-13.so.1+0xd27b05)
 #4 0x00007f1b7011a140 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x13140)
 #5 0x00007f1b6d812dcc clang::DeclarationName::getAsString[abi:cxx11]() const (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0xe50dcc)
 #6 0x00007f1b6f184c0e (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x27c2c0e)
 #7 0x00007f1b6f185edb (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x27c3edb)
 #8 0x00007f1b6f184383 (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x27c2383)
 #9 0x00007f1b6f186c4d (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x27c4c4d)
#10 0x00007f1b6f096caf clang::ento::CheckerManager::runCheckersForEvalCall(clang::ento::ExplodedNodeSet&, clang::ento::ExplodedNodeSet const&, clang::ento::CallEvent const&, clang::ento::ExprEngine&, clang::ento::EvalCallOptions const&) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x26d4caf)
#11 0x00007f1b6f0cfbee clang::ento::ExprEngine::evalCall(clang::ento::ExplodedNodeSet&, clang::ento::ExplodedNode*, clang::ento::CallEvent const&) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x270dbee)
#12 0x00007f1b6f0cf8f4 clang::ento::ExprEngine::VisitCallExpr(clang::CallExpr const*, clang::ento::ExplodedNode*, clang::ento::ExplodedNodeSet&) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x270d8f4)
#13 0x00007f1b6f0b52c3 clang::ento::ExprEngine::Visit(clang::Stmt const*, clang::ento::ExplodedNode*, clang::ento::ExplodedNodeSet&) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x26f32c3)
#14 0x00007f1b6f0b2575 clang::ento::ExprEngine::ProcessStmt(clang::Stmt const*, clang::ento::ExplodedNode*) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x26f0575)
#15 0x00007f1b6f0b226e clang::ento::ExprEngine::processCFGElement(clang::CFGElement, clang::ento::ExplodedNode*, unsigned int, clang::ento::NodeBuilderContext*) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x26f026e)
#16 0x00007f1b6f09d41c clang::ento::CoreEngine::dispatchWorkItem(clang::ento::ExplodedNode*, clang::ProgramPoint, clang::ento::WorkListUnit const&) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x26db41c)
#17 0x00007f1b6f09d139 clang::ento::CoreEngine::ExecuteWorkList(clang::LocationContext const*, unsigned int, llvm::IntrusiveRefCntPtr<clang::ento::ProgramState const>) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x26db139)
#18 0x00007f1b6f42ba2c (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x2a69a2c)
#19 0x00007f1b6f413d8e (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x2a51d8e)
#20 0x00007f1b6d5dff64 clang::ParseAST(clang::Sema&, bool, bool) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0xc1df64)
#21 0x00007f1b6ee4e716 clang::FrontendAction::Execute() (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x248c716)
#22 0x00007f1b6edc8eb6 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x2406eb6)
#23 0x00007f1b6eec1e86 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x24ffe86)
#24 0x0000000000413d89 (clang+0x413d89)
#25 0x0000000000411da6 (clang+0x411da6)
#26 0x00007f1b6eac6852 (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x2104852)
#27 0x00007f1b6771585d llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) (/usr/lib/x86_64-linux-gnu/libLLVM-13.so.1+0xd2785d)
#28 0x00007f1b6eac6130 clang::driver::CC1Command::Execute(llvm::ArrayRef<llvm::Optional<llvm::StringRef> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, bool*) const (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x2104130)
#29 0x00007f1b6ea99b40 clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&) const (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x20d7b40)
#30 0x00007f1b6ea99f2a clang::driver::Compilation::ExecuteJobs(clang::driver::JobList const&, llvm::SmallVectorImpl<std::pair<int, clang::driver::Command const*> >&) const (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x20d7f2a)
#31 0x00007f1b6eaaf07e clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::pair<int, clang::driver::Command const*> >&) (/usr/lib/x86_64-linux-gnu/libclang-cpp.so.13+0x20ed07e)
#32 0x00000000004115e3 (clang+0x4115e3)
#33 0x00007f1b6650fd0a __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x23d0a)
#34 0x000000000040ee3a (clang+0x40ee3a)
clang: error: clang frontend command failed with exit code 139 (use -v to see invocation)
Debian clang version 13.0.1-++20220126092033+75e33f71c2da-1~exp1~20220126212112.63
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
clang: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang: note: diagnostic msg: /tmp/crash-82387c.cpp
clang: note: diagnostic msg: /tmp/crash-82387c.sh
clang: note: diagnostic msg: 

********************
```
